### PR TITLE
Migrations are now a Composer package

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -78,19 +78,19 @@ cs-fix: ## Fix code style issues
 	docker compose run --rm webapp bash -c "vendor/bin/phpcbf ${OPTS} && vendor/bin/phpcs ${OPTS}"
 
 create-migration: ## Create a new database migration
-	docker compose run --rm webapp vendor/bin/phinx create ${OPTS} -c db/phinx.php
+	docker compose run --rm webapp vendor/bin/phinx create ${OPTS} -c vendor/aspirepress/aspirecloud-migrations/phinx.php
 
 create-seed: ##	Create a new database seed
-	docker compose run --rm webapp vendor/bin/phinx seed:create ${OPTS} -c db/phinx.php
+	docker compose run --rm webapp vendor/bin/phinx seed:create ${OPTS} -c vendor/aspirepress/aspirecloud-migrations/phinx.php
 
 migrate: ## Run database migrations
-	docker compose run --rm webapp vendor/bin/phinx migrate -c db/phinx.php
+	docker compose run --rm webapp vendor/bin/phinx migrate -c vendor/aspirepress/aspirecloud-migrations/phinx.php
 
 migration-rollback: ## Rollback database migrations
-	docker compose run --rm webapp vendor/bin/phinx rollback -e development -c db/phinx.php
+	docker compose run --rm webapp vendor/bin/phinx rollback -e development -c vendor/aspirepress/aspirecloud-migrations/phinx.php
 
 seed: ## Run database seeds
-	docker compose run --rm webapp vendor/bin/phinx seed:run -c db/phinx.php
+	docker compose run --rm webapp vendor/bin/phinx seed:run -c vendor/aspirepress/aspirecloud-migrations/phinx.php
 
 devmode-enable: ## Enable the PHP development mode
 	docker compose run --rm webapp composer development-enable
@@ -99,16 +99,16 @@ devmode-disable: ## Disable the PHP development mode
 	docker compose run --rm webapp composer development-disable
 
 _empty-database: # internal target to empty database
-	docker compose run --rm webapp vendor/bin/phinx migrate -c db/phinx.php -t 0
+	docker compose run --rm webapp vendor/bin/phinx migrate -c vendor/aspirepress/aspirecloud-migrations/phinx.php -t 0
 
 migrate-testing: ## Run database migrations
-	docker compose run --rm webapp vendor/bin/phinx migrate -e testing -c db/phinx.php
+	docker compose run --rm webapp vendor/bin/phinx migrate -e testing -c vendor/aspirepress/aspirecloud-migrations/phinx.php
 
 seed-testing: ## Run database seeds
-	docker compose run --rm webapp vendor/bin/phinx seed:run -e testing -c db/phinx.php
+	docker compose run --rm webapp vendor/bin/phinx seed:run -e testing -c vendor/aspirepress/aspirecloud-migrations/phinx.php
 
 _empty-testing-database: # internal target to empty database
-	docker compose run --rm webapp vendor/bin/phinx migrate -e testing -c db/phinx.php -t 0
+	docker compose run --rm webapp vendor/bin/phinx migrate -e testing -c vendor/aspirepress/aspirecloud-migrations/phinx.php -t 0
 
 reset-database: _empty-database migrate seed ## Clean database, run migrations and seeds
 

--- a/Makefile
+++ b/Makefile
@@ -77,12 +77,6 @@ cs: ## Run code style checks
 cs-fix: ## Fix code style issues
 	docker compose run --rm webapp bash -c "vendor/bin/phpcbf ${OPTS} && vendor/bin/phpcs ${OPTS}"
 
-create-migration: ## Create a new database migration
-	docker compose run --rm webapp vendor/bin/phinx create ${OPTS} -c vendor/aspirepress/aspirecloud-migrations/phinx.php
-
-create-seed: ##	Create a new database seed
-	docker compose run --rm webapp vendor/bin/phinx seed:create ${OPTS} -c vendor/aspirepress/aspirecloud-migrations/phinx.php
-
 migrate: ## Run database migrations
 	docker compose run --rm webapp vendor/bin/phinx migrate -c vendor/aspirepress/aspirecloud-migrations/phinx.php
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,6 @@ This project is designed to function as a CDN/API endpoint system for distributi
 ### Quick Start
 
 ```
-git submodule update --init --recursive
 cp .env.dist .env
 make init
 ```

--- a/composer.json
+++ b/composer.json
@@ -10,6 +10,12 @@
             "ramsey/composer-repl": true
         }
     },
+    "repositories": [
+        {
+            "type": "vcs",
+            "url": "https://github.com/aspirepress/aspirecloud-migrations.git"
+        }
+    ],
     "require": {
         "php": "^8.3",
         "aura/sql": "^5.0",
@@ -29,7 +35,8 @@
         "ramsey/composer-repl": "^1.4",
         "ramsey/uuid": "^4.7",
         "robmorgan/phinx": "^0.16.0",
-        "webmozart/assert": "^1.11"
+        "webmozart/assert": "^1.11",
+        "aspirepress/aspirecloud-migrations": "dev-main"
     },
     "require-dev": {
         "behat/behat": "^3.11",

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,42 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "6c6fd006490a902f9f5fbd85b4d4db78",
+    "content-hash": "d12243484c3bde20f12e0258761cf493",
     "packages": [
+        {
+            "name": "aspirepress/aspirecloud-migrations",
+            "version": "dev-main",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/aspirepress/aspirecloud-migrations.git",
+                "reference": "f0e80a0ddcfaa3f4c73e269fb0fa885ebc632abc"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/aspirepress/aspirecloud-migrations/zipball/f0e80a0ddcfaa3f4c73e269fb0fa885ebc632abc",
+                "reference": "f0e80a0ddcfaa3f4c73e269fb0fa885ebc632abc",
+                "shasum": ""
+            },
+            "require": {
+                "robmorgan/phinx": "^0.16.5"
+            },
+            "default-branch": true,
+            "type": "library",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Sarah Savage"
+                }
+            ],
+            "description": "A set of migrations to run for AspireCloud",
+            "support": {
+                "source": "https://github.com/aspirepress/aspirecloud-migrations/tree/main",
+                "issues": "https://github.com/aspirepress/aspirecloud-migrations/issues"
+            },
+            "time": "2024-10-14T19:47:54+00:00"
+        },
         {
             "name": "aura/sql",
             "version": "5.0.2",
@@ -8369,12 +8403,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/Roave/SecurityAdvisories.git",
-                "reference": "6fc16d8c05a872bf86eb0a1684d89b9bcb93d636"
+                "reference": "c3c55a0f6643119fa8699577cc83ca6256d98ab5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Roave/SecurityAdvisories/zipball/6fc16d8c05a872bf86eb0a1684d89b9bcb93d636",
-                "reference": "6fc16d8c05a872bf86eb0a1684d89b9bcb93d636",
+                "url": "https://api.github.com/repos/Roave/SecurityAdvisories/zipball/c3c55a0f6643119fa8699577cc83ca6256d98ab5",
+                "reference": "c3c55a0f6643119fa8699577cc83ca6256d98ab5",
                 "shasum": ""
             },
             "conflict": {
@@ -8711,7 +8745,7 @@
                 "lms/routes": "<2.1.1",
                 "localizationteam/l10nmgr": "<7.4|>=8,<8.7|>=9,<9.2",
                 "luyadev/yii-helpers": "<1.2.1",
-                "magento/community-edition": "<2.4.5|==2.4.5|>=2.4.5.0-patch1,<2.4.5.0-patch9|==2.4.6|>=2.4.6.0-patch1,<2.4.6.0-patch7|==2.4.7|>=2.4.7.0-patch1,<2.4.7.0-patch2",
+                "magento/community-edition": "<2.4.5|==2.4.5|>=2.4.5.0-patch1,<2.4.5.0-patch10|==2.4.6|>=2.4.6.0-patch1,<2.4.6.0-patch8|>=2.4.7.0-beta1,<2.4.7.0-patch3",
                 "magento/core": "<=1.9.4.5",
                 "magento/magento1ce": "<1.9.4.3-dev",
                 "magento/magento1ee": ">=1,<1.14.4.3-dev",
@@ -8944,7 +8978,7 @@
                 "slim/slim": "<2.6",
                 "slub/slub-events": "<3.0.3",
                 "smarty/smarty": "<4.5.3|>=5,<5.1.1",
-                "snipe/snipe-it": "<6.4.2",
+                "snipe/snipe-it": "<7.0.10",
                 "socalnick/scn-social-auth": "<1.15.2",
                 "socialiteproviders/steam": "<1.1",
                 "spatie/browsershot": "<3.57.4",
@@ -9192,7 +9226,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-10-10T00:18:21+00:00"
+            "time": "2024-10-11T18:06:00+00:00"
         },
         {
             "name": "symfony/dependency-injection",
@@ -9754,6 +9788,7 @@
     "aliases": [],
     "minimum-stability": "stable",
     "stability-flags": {
+        "aspirepress/aspirecloud-migrations": 20,
         "roave/security-advisories": 20
     },
     "prefer-stable": false,
@@ -9761,6 +9796,6 @@
     "platform": {
         "php": "^8.3"
     },
-    "platform-dev": [],
+    "platform-dev": {},
     "plugin-api-version": "2.6.0"
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,6 @@ services:
       context: .
       dockerfile: ./docker/nginx/Dockerfile
     ports:
-      - 8099:80
       - 8100:443
     volumes:
       - .:/var/www/html

--- a/docker/nginx/default
+++ b/docker/nginx/default
@@ -1,9 +1,4 @@
 server {
-    listen 80 default_server;
-    return 302 https://$host$request_uri;
-}
-
-server {
     listen 443 ssl;
     client_max_body_size 4M;
 


### PR DESCRIPTION
# Pull Request

## What changed?

* Converted migrations from a Git submodule to a Composer package.

## Why did it change?

People were struggling with using submodules so I wanted to simplify things.

## Did you fix any specific issues?

The issue with submodules.

## CERTIFICATION

By opening this pull request, I do agree to abide by the [CODE OF CONDUCT](https://github.com/aspirepress/.github/CODE_OF_CONDUCT.md) and be bound by the terms
of the [Contribution Guidelines](https://github.com/aspirepress/.github/CONTRIBUTING.md) in effect on the date and time of my contribution as proven by the
revision information in GitHub. I also agree that any previous contributions shall be deemed subject to the terms of the
version in effect on the date and time of this pull request, or any future revisions for pull requests I may submit.

Further, I certify that this work is my own, is original, does not violate the intellectual property of any other person
or entity, and I am not violating any license agreements or contracts I have with any person or entity.

Finally, I agree that this code may be licensed under any license deemed appropraite by AspirePress, including but not
limited to open source, closed source, proprietary or custom licenses, and that such license terms neither violate my
rights or my copyright to this code. 

(Please check a box below)

[X] I agree
[ ] I do not agree