### PR TITLE
infra: add .gitattributes file to prevent CRLF translation in scripts

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+# Force LF only on files where CRLF is deadly; git defaults are fine for the rest.
+*.bash text=auto eol=lf
+*.sh text=auto eol=lf


### PR DESCRIPTION
# Pull Request

## What changed?

Added a .gitattributes file that should prevent stray `\r` characters in shell scripts. 

## Why did it change?

Reports from windows users seeing the files mangled this way.

## Did you fix any specific issues?

none, this is a drive-by fix

## CERTIFICATION

By opening this pull request, I do agree to abide by the [CODE OF CONDUCT](https://github.com/aspirepress/.github/CODE_OF_CONDUCT.md) and be bound by the terms
of the [Contribution Guidelines](https://github.com/aspirepress/.github/CONTRIBUTING.md) in effect on the date and time of my contribution as proven by the
revision information in GitHub. I also agree that any previous contributions shall be deemed subject to the terms of the
version in effect on the date and time of this pull request, or any future revisions for pull requests I may submit.

Further, I certify that this work is my own, is original, does not violate the intellectual property of any other person
or entity, and I am not violating any license agreements or contracts I have with any person or entity.

Finally, I agree that this code may be licensed under any license deemed appropraite by AspirePress, including but not
limited to open source, closed source, proprietary or custom licenses, and that such license terms neither violate my
rights or my copyright to this code. 

(Please check a box below)

[X] I agree
[ ] I do not agree