### PR TITLE
Add endpoints for theme info and collect pass through data

### DIFF
--- a/app/Http/Controllers/CatchAllController.php
+++ b/app/Http/Controllers/CatchAllController.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use Illuminate\Http\Client\RequestException;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Str;
+use Illuminate\Http\Response;
+use Illuminate\Support\Carbon;
+
+class CatchAllController extends Controller
+{
+    public function handle(Request $request)
+    {
+        $requestData = $request->all();
+        $ua = $request->header('User-Agent');
+        $path = $request->path();
+        $queryParams = $request->query();
+
+        // If path is root, return a 200 OK empty response
+        if ($path === '/') {
+            return response()->noContent(200); 
+        }
+
+        try {
+            $response = Http::withHeaders([
+                'User-Agent' => $ua,
+                'Accept' => '*/*'
+            ])->asForm()->send($request->getMethod(), 'https://api.wordpress.org/' . $path, [
+                'query' => $queryParams,
+                'form_params' => $requestData
+            ]);
+
+        } catch (RequestException $e) {
+            $statusCode = $e->response ? $e->response->status() : 500;
+            return response()->noContent($statusCode);
+        }
+
+        // Get content type and status code
+        $contentType = $response->header('Content-Type');
+        $statusCode = $response->status();
+        $content = $response->body();
+
+        // Log request and response in DB
+        $this->saveData($request, $response, $content);
+
+        // Forward response through
+        return response($content, $statusCode)->header('Content-Type', $contentType);
+    }
+
+    private function saveData(Request $request, $response, string $content): void
+    {
+        DB::table('request_data')->insert([
+            'id' => Str::uuid()->toString(), 
+            'request_path' => $request->path(),
+            'request_query_params' => json_encode($request->query()),
+            'request_body' => json_encode($request->all()),
+            'request_headers' => json_encode($request->headers->all()),
+            'response_code' => $response->status(),
+            'response_body' => $content,
+            'response_headers' => json_encode($response->headers()),
+            'created_at' => Carbon::now(),
+        ]);
+    }
+}

--- a/app/Http/Controllers/CatchAllController.php
+++ b/app/Http/Controllers/CatchAllController.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Controllers;
 
+use App\Jobs\ProcessWpOrgResponse;
 use Illuminate\Http\Client\RequestException;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\DB;
@@ -45,7 +46,7 @@ class CatchAllController extends Controller
 
         // Log request and response in DB
         $this->saveData($request, $response, $content);
-
+        ProcessWpOrgResponse::dispatchSync($content);
         // Forward response through
         return response($content, $statusCode)->header('Content-Type', $contentType);
     }

--- a/app/Http/Controllers/ThemeController.php
+++ b/app/Http/Controllers/ThemeController.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use Illuminate\Http\Request;
+use App\Models\ApiResultsResponse;
+
+class ThemeController extends Controller
+{
+     // Method for v1.0 (PHP serialized data)
+    public function infoV1()
+    {
+        $themes = \DB::table('themes')->get()->toArray();
+        $response = new ApiResultsResponse('themes', $themes, 1, 1);
+        return response(serialize($response->toStdClass()), 200);
+    }
+
+     // Method for v1.1 (JSON response)
+    public function infoV1_1()
+    {
+        return response()->json(['theme' => 'example', 'version' => '1.1']);
+    }
+
+    public function infoV1_2(Request $request)
+    {
+        $requestData = $request->query('request');
+
+        $page = $requestData['page'];
+        $perPage = $requestData['per_page'];
+        $skip = ($page - 1) * $perPage;
+        $themes = \DB::table('themes')->skip($skip)->take($perPage)->get()->toArray();
+        $total = \DB::table('themes')->count();
+        $response = new ApiResultsResponse('themes', $themes, $page, $perPage, $total);
+        return response()->json($response);
+    }
+}

--- a/app/Jobs/ProcessWpOrgResponse.php
+++ b/app/Jobs/ProcessWpOrgResponse.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace App\Jobs;
+
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Queue\Queueable;
+
+class ProcessWpOrgResponse implements ShouldQueue
+{
+    use Queueable;
+
+    private $responseContent;
+    /**
+     * Create a new job instance.
+     */
+    public function __construct($responseContent)
+    {
+        $this->responseContent = $responseContent;
+    }
+
+    /**
+     * Execute the job.
+     */
+    public function handle(): void
+    {
+            $responseAsJson = json_decode($this->responseContent);
+
+            // has themes prop
+        if (isset($responseAsJson->themes)) {
+            $mappedThemes = array_map(function ($themeInfo) {
+                return [
+                    'id' => \Str::uuid()->toString(),
+                    'name' => $themeInfo->name,
+                    'slug' => $themeInfo->slug,
+                    'current_version' => $themeInfo->version,
+                    'metadata' => json_encode($themeInfo)
+                ];
+            }, $responseAsJson->themes);
+            \DB::table('themes')->upsert($mappedThemes, ['slug'], ['name','current_version','metadata']);
+        }
+
+             // has themes prop
+        if (isset($responseAsJson->plugins)) {
+            $mappedPlugins = array_map(function ($pluginInfo) {
+                    return [
+                        'id' => \Str::uuid()->toString(),
+                        'name' => $pluginInfo->name,
+                        'slug' => $pluginInfo->slug,
+                        'current_version' => $pluginInfo->version,
+                        'metadata' => json_encode($pluginInfo)
+                    ];
+            }, $responseAsJson->plugins);
+            \DB::table('plugins')->upsert($mappedPlugins, ['slug'], ['name','current_version','metadata']);
+        }
+    }
+}

--- a/app/Models/ApiResultsResponse.php
+++ b/app/Models/ApiResultsResponse.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace App\Models;
+
+class ApiResultsResponse implements \JsonSerializable
+{
+    protected $results;
+    protected $page;
+    protected $pages;
+    protected $totalResults;
+    protected $type;
+
+    public function __construct(string $type, array $results, int $page, int $perPage, int $total)
+    {
+        $this->type = $type;
+        $this->results = $results;
+        $this->totalResults = $total;
+        $this->page = $page;
+        $this->pages = ceil($total / $perPage);
+    }
+
+    // Info section to be used in the JSON output
+    public function info(): array
+    {
+        return [
+            'page' => $this->page,
+            'pages' => $this->pages,
+            'results' => $this->totalResults,
+        ];
+    }
+
+    public function getData()
+    {
+        return array_map(function ($record) {
+            return json_decode($record->metadata);
+        }, $this->results);
+    }
+
+    public function toStdClass(): \stdClass
+    {
+        $data = new \stdClass();
+        $data->info = (object) $this->info();
+        $data->{$this->type} = (object) $this->getData();  // or an array if needed
+
+        return $data;
+    }
+    public function jsonSerialize() : mixed
+    {
+        return [
+            'info' => $this->info(),
+            $this->type => $this->getData(),
+        ];
+    }
+}

--- a/database/migrations/2024_10_19_041201_add_indexing_to_schema.php
+++ b/database/migrations/2024_10_19_041201_add_indexing_to_schema.php
@@ -1,0 +1,34 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('themes', function (Blueprint $table) {
+            $table->unique('slug','theme_slug_unique');
+        });        Schema::table('plugins', function (Blueprint $table) {
+            $table->unique('slug','plugin_slug_unique');
+        });
+    
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('themes', function (Blueprint $table) {
+            $table->dropIndex('theme_slug_unique');
+        });
+        Schema::table('plugins', function (Blueprint $table) {
+            $table->dropIndex('plugin_slug_unique');
+        });
+    }
+};

--- a/routes/web.php
+++ b/routes/web.php
@@ -1,7 +1,10 @@
 <?php
 
+use App\Http\Controllers\CatchAllController;
 use Illuminate\Support\Facades\Route;
 
 Route::get('/', function () {
     return view('welcome');
 });
+
+Route::any('{path}', [CatchAllController::class, 'handle'])->where('path', '.*');

--- a/routes/web.php
+++ b/routes/web.php
@@ -1,10 +1,20 @@
 <?php
 
 use App\Http\Controllers\CatchAllController;
+use App\Http\Controllers\ThemeController;
 use Illuminate\Support\Facades\Route;
 
 Route::get('/', function () {
     return view('welcome');
 });
+
+$passThroughEnabled = (bool) env('AC_PASS_THROUGH', false);
+if (!$passThroughEnabled) {
+    Route::group(['prefix' => 'themes/info'], function () {
+        Route::get('1.0', [ThemeController::class, 'infoV1']); // PHP serialized response
+        Route::get('1.1', [ThemeController::class, 'infoV1_1']); // JSON response
+        Route::get('1.2', [ThemeController::class, 'infoV1_2']); // JSON response
+    });
+}
 
 Route::any('{path}', [CatchAllController::class, 'handle'])->where('path', '.*');


### PR DESCRIPTION
# Pull Request

## What changed?

1. **Routes**
Added endpoints for theme info 
Added conditional env variable to routes to turn pass through on/off for themes

Added a ThemesController which fetches data and then returns it in the expected format. (basic query themes response only at this stage)

2. **Models**
Created APIResultsResponse class for structuring data

3. **Data**
Added migration to add unique index to themes and plugins

4. **Jobs**
Added a new job for processing responses as they are passed through the catch all controller.
The job handler will look for either a themes or plugins property on the response. If one is found, data is inserted (or updated) in the database. 

Note:  this is dispatched synchronously





## Why did it change?

Initial implementation of the themes endpoints

## Did you fix any specific issues?


## CERTIFICATION

By opening this pull request, I do agree to abide by
the [CODE OF CONDUCT](https://github.com/aspirepress/.github/CODE_OF_CONDUCT.md) and be bound by the terms
of the [Contribution Guidelines](https://github.com/aspirepress/.github/CONTRIBUTING.md) in effect on the date and time
of my contribution as proven by the
revision information in GitHub. I also agree that any previous contributions shall be deemed subject to the terms of the
version in effect on the date and time of this pull request, or any future revisions for pull requests I may submit.
Further, I certify that this work is my own, is original, does not violate the intellectual property of any other person
or entity, and I am not violating any license agreements or contracts I have with any person or entity. Finally, I agree
that this code may be licensed under any license deemed appropraite by AspirePress, including but not
limited to open source, closed source, proprietary or custom licenses, and that such license terms neither violate my
rights or my copyright to this code.