### PR TITLE
fix: make current_version columns nullable

### DIFF
--- a/database/migrations/2024_10_18_174143_initial_schema.php
+++ b/database/migrations/2024_10_18_174143_initial_schema.php
@@ -11,7 +11,7 @@ return new class extends Migration {
             $table->uuid('id')->primary();
             $table->string('name');
             $table->string('slug')->unique();
-            $table->string('current_version');
+            $table->string('current_version')->nullable();
             $table->dateTime('updated')->useCurrent();
             $table->string('status')->default('open');
             $table->dateTime('pulled_at')->useCurrent();
@@ -66,7 +66,7 @@ return new class extends Migration {
             $table->uuid('id')->primary();
             $table->string('name', 255);
             $table->string('slug', 255);
-            $table->string('current_version', 255);
+            $table->string('current_version', 255)->nullable();
             $table->dateTime('updated')->useCurrent();
             $table->dateTime('pulled_at')->useCurrent();
             $table->jsonb('metadata')->nullable();


### PR DESCRIPTION
# Pull Request

## What changed?

made the current_version column nullable in plugins and themes tables.  I edited the existing initial migration to do so because it's brand new and there aren't any running instances that need to stay that way.  `make reset-database` will do the trick for an existing instance.


## Why did it change?

AspireSync needs these to be nullable

## Did you fix any specific issues?

none

## CERTIFICATION

By opening this pull request, I do agree to abide by
the [CODE OF CONDUCT](https://github.com/aspirepress/.github/CODE_OF_CONDUCT.md) and be bound by the terms
of the [Contribution Guidelines](https://github.com/aspirepress/.github/CONTRIBUTING.md) in effect on the date and time
of my contribution as proven by the
revision information in GitHub. I also agree that any previous contributions shall be deemed subject to the terms of the
version in effect on the date and time of this pull request, or any future revisions for pull requests I may submit.
Further, I certify that this work is my own, is original, does not violate the intellectual property of any other person
or entity, and I am not violating any license agreements or contracts I have with any person or entity. Finally, I agree
that this code may be licensed under any license deemed appropraite by AspirePress, including but not
limited to open source, closed source, proprietary or custom licenses, and that such license terms neither violate my
rights or my copyright to this code.