### PR TITLE
ci: run CI on PRs to main and main merges

### DIFF
--- a/.github/workflows/run-checks.yaml
+++ b/.github/workflows/run-checks.yaml
@@ -1,6 +1,10 @@
 name: Commit Pipeline
 
-on: [push, pull_request]
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
 
 jobs:
   build:
@@ -28,5 +32,3 @@ jobs:
           vendor/bin/php-cs-fixer check
           vendor/bin/phpstan --memory-limit=1G analyse
           php artisan test tests/Unit
-
-


### PR DESCRIPTION
# Pull Request

## What changed?

Changed the github CI action to only run on PRs merging to main and after a merge to main. 

## Why did it change?

This is a pretty ideal balance.  If a long-term branch needs CI, they can bring a GH action along for the ride that does so.

## Did you fix any specific issues?

none

## CERTIFICATION

By opening this pull request, I do agree to abide by
the [CODE OF CONDUCT](https://github.com/aspirepress/.github/CODE_OF_CONDUCT.md) and be bound by the terms
of the [Contribution Guidelines](https://github.com/aspirepress/.github/CONTRIBUTING.md) in effect on the date and time
of my contribution as proven by the
revision information in GitHub. I also agree that any previous contributions shall be deemed subject to the terms of the
version in effect on the date and time of this pull request, or any future revisions for pull requests I may submit.
Further, I certify that this work is my own, is original, does not violate the intellectual property of any other person
or entity, and I am not violating any license agreements or contracts I have with any person or entity. Finally, I agree
that this code may be licensed under any license deemed appropraite by AspirePress, including but not
limited to open source, closed source, proprietary or custom licenses, and that such license terms neither violate my
rights or my copyright to this code.