### PR TITLE
fix: drop slug column from plugin_files

### DIFF
--- a/app/Models/PluginFile.php
+++ b/app/Models/PluginFile.php
@@ -16,7 +16,6 @@ class PluginFile extends BaseModel
     {
         return [
             'id' => 'string',
-            'slug' => 'string',
             'file_url' => 'string',
             'type' => 'string',
             'version' => 'string',

--- a/database/migrations/2024_10_18_174143_initial_schema.php
+++ b/database/migrations/2024_10_18_174143_initial_schema.php
@@ -25,7 +25,6 @@ return new class extends Migration {
                 ->on('plugins')
                 ->cascadeOnUpdate()
                 ->cascadeOnDelete();
-            $table->string('slug')->unique();
             $table->string('file_url')->nullable();
             $table->string('type');
             $table->string('version');


### PR DESCRIPTION
# Pull Request

## What changed?

Drops the `slug` column from the plugin_files table in migrations.  I edited the migration again instead of making a new one, which I'll do until things actually start using those tables.

## Why did it change?

it was added by accident and never should have been there; aspiresync was crashing because of it

## Did you fix any specific issues?

none

## CERTIFICATION

By opening this pull request, I do agree to abide by
the [CODE OF CONDUCT](https://github.com/aspirepress/.github/CODE_OF_CONDUCT.md) and be bound by the terms
of the [Contribution Guidelines](https://github.com/aspirepress/.github/CONTRIBUTING.md) in effect on the date and time
of my contribution as proven by the
revision information in GitHub. I also agree that any previous contributions shall be deemed subject to the terms of the
version in effect on the date and time of this pull request, or any future revisions for pull requests I may submit.
Further, I certify that this work is my own, is original, does not violate the intellectual property of any other person
or entity, and I am not violating any license agreements or contracts I have with any person or entity. Finally, I agree
that this code may be licensed under any license deemed appropraite by AspirePress, including but not
limited to open source, closed source, proprietary or custom licenses, and that such license terms neither violate my
rights or my copyright to this code.