### PR TITLE
feat: Implements sorting by the browse parameter

### DIFF
--- a/app/Http/Controllers/API/WpOrg/Plugins/Plugin_1_2_Controller.php
+++ b/app/Http/Controllers/API/WpOrg/Plugins/Plugin_1_2_Controller.php
@@ -51,6 +51,7 @@ class Plugin_1_2_Controller extends Controller
         $search = $request->query('search');
         $tag = $request->query('tag');
         $author = $request->query('author');
+        $browse = $request->query('browse', 'popular');
 
         // Build query
         $query = Plugin::query()
@@ -68,13 +69,21 @@ class Plugin_1_2_Controller extends Controller
                 $query->where('author', 'like', "%{$author}%");
             });
 
+        // Apply sorting based on the browse parameter
+        match ($browse) {
+            'new' => $query->orderBy('added', 'desc'),
+            'updated' => $query->orderBy('last_updated', 'desc'),
+            // TODO: Implement a better top-rated sorting?
+            'top-rated' => $query->orderBy('rating', 'desc'),
+            // TODO: Implement a better popular sorting, active_installs, downloaded?
+            default => $query->orderBy('active_installs', 'desc')
+        };
         // Get total count for pagination
         $total = $query->count();
         $totalPages = (int) ceil($total / $perPage);
 
         // Get paginated results
         $plugins = $query
-            ->orderBy('last_updated', 'desc')
             ->offset(($page - 1) * $perPage)
             ->limit($perPage)
             ->get();


### PR DESCRIPTION
# Pull Request

## What changed?

The Plugin API v1.2 handle function

## Why did it change?

Implements the sorting based on the `browse` parameter, supports:

- new
- updated
- top-rated
- popular (default)

The `top-rated` and `popular` sorting are basic right now. I can't find how those sorting works on .org for now; as you can see, the `top-rated` sorting is based on the `rating` field, and the `popular` sorting is based on the `active_install` field.

We can play with this in the future.

Also, the .org API looks like does not seem to support an option to change the `DESC` and `ASC` order. Should we support that option?

## Did you fix any specific issues?

N/A

## CERTIFICATION

By opening this pull request, I do agree to abide by
the [CODE OF CONDUCT](https://github.com/aspirepress/.github/CODE_OF_CONDUCT.md) and be bound by the terms
of the [Contribution Guidelines](https://github.com/aspirepress/.github/CONTRIBUTING.md) in effect on the date and time
of my contribution as proven by the
revision information in GitHub. I also agree that any previous contributions shall be deemed subject to the terms of the
version in effect on the date and time of this pull request, or any future revisions for pull requests I may submit.
Further, I certify that this work is my own, is original, does not violate the intellectual property of any other person
or entity, and I am not violating any license agreements or contracts I have with any person or entity. Finally, I agree
that this code may be licensed under any license deemed appropraite by AspirePress, including but not
limited to open source, closed source, proprietary or custom licenses, and that such license terms neither violate my
rights or my copyright to this code.