### PR TITLE
Implement hot_tags on ThemeController->info

### DIFF
--- a/app/Data/WpOrg/Themes/HotTagsResponse.php
+++ b/app/Data/WpOrg/Themes/HotTagsResponse.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace App\Data\WpOrg\Themes;
+
+use Illuminate\Support\Collection;
+use Spatie\LaravelData\Data;
+
+class HotTagsResponse extends Data
+{
+    public function __construct(
+        public string $slug,
+        public string $name,
+        public int $count,
+    ) {}
+
+    /**
+    * Static method to create an instance from a Theme model.
+    * @param Collection<string|int,covariant array{
+    *   slug: string,
+    *   name: string,
+    *   count: int,
+    * }> $themeTags
+    * @return Collection<string, covariant HotTagsResponse>
+    */
+    public static function fromCollection(Collection $themeTags): Collection
+    {
+        return $themeTags->mapWithKeys(fn($theme) => [
+            $theme['slug'] => self::from($theme),
+        ]);
+    }
+}

--- a/app/Data/WpOrg/Themes/HotTagsResponse.php
+++ b/app/Data/WpOrg/Themes/HotTagsResponse.php
@@ -14,14 +14,14 @@ class HotTagsResponse extends Data
     ) {}
 
     /**
-    * Static method to create an instance from a Theme model.
-    * @param Collection<string|int,covariant array{
-    *   slug: string,
-    *   name: string,
-    *   count: int,
-    * }> $themeTags
-    * @return Collection<string, covariant HotTagsResponse>
-    */
+     * Static method to create an instance from a Theme model.
+     * @param Collection<int,covariant array{
+     *   slug: string,
+     *   name: string,
+     *   count: int,
+     * }> $themeTags
+     * @return Collection<string, covariant HotTagsResponse>
+     */
     public static function fromCollection(Collection $themeTags): Collection
     {
         return $themeTags->mapWithKeys(fn($theme) => [

--- a/app/Data/WpOrg/Themes/QueryThemesRequest.php
+++ b/app/Data/WpOrg/Themes/QueryThemesRequest.php
@@ -37,6 +37,7 @@ class QueryThemesRequest extends Data
             $req['tags'] = is_array($req['tag']) ? $req['tag'] : [$req['tag']];
             unset($req['tag']);
         }
+
         $defaultFields = [
             'description' => true,
             'rating'      => true,

--- a/app/Data/WpOrg/Themes/QueryThemesRequest.php
+++ b/app/Data/WpOrg/Themes/QueryThemesRequest.php
@@ -13,7 +13,7 @@ class QueryThemesRequest extends Data
 
     /**
      * @param ?string[] $tags
-     * @param ?array<string,bool> $fields
+     * @param string|array<string,bool> $fields
      */
     public function __construct(
         public readonly ?string $search = null, // text to search
@@ -21,7 +21,7 @@ class QueryThemesRequest extends Data
         public readonly ?string $theme = null,  // slug of a specific theme
         public readonly ?string $author = null, // wp.org username of author
         public readonly ?string $browse = null, // one of popular|featured|updated|new
-        public readonly ?array $fields = null,
+        public readonly mixed $fields = null,
         public readonly int $page = 1,
         public readonly int $per_page = 24,
     ) {}

--- a/app/Http/Resources/ThemeResource.php
+++ b/app/Http/Resources/ThemeResource.php
@@ -90,8 +90,7 @@ class ThemeResource extends JsonResource
             'homepage' => $this->whenField('homepage', fn() => "https://wordpress.org/themes/{$this->resource->slug}/"),
             'download_link' => $this->whenField('downloadlink', fn() => $this->resource->download_link ?? ''),
             'tags' => $this->whenField('tags', function () {
-                return [];
-                // TODO: return collect($this->resource->tags)->mapWithKeys(fn($tag) => [$tag->slug => $tag->name]);
+                return $this->resource->tags;
             }),
             'versions' => $this->whenField('versions', function () {
                 return [];

--- a/app/Models/WpOrg/PluginTag.php
+++ b/app/Models/WpOrg/PluginTag.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace App\Models\WpOrg;
+
+use App\Models\BaseModel;
+use App\Models\Sync\SyncTheme;
+use Carbon\Carbon;
+use Carbon\CarbonImmutable;
+use Illuminate\Database\Eloquent\Concerns\HasUuids;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+use Illuminate\Support\Facades\DB;
+use InvalidArgumentException;
+
+/**
+ * @property string $id
+ * @property string $theme_id
+ * @property string $slug
+ */
+final class PluginTag extends BaseModel
+{
+    //region Model Definition
+
+    use HasUuids;
+
+    protected $table = 'plugin_tags';
+
+    protected function casts(): array
+    {
+        return [
+            'id' => 'string',
+            'slug' => 'string',
+            'plugin_id' => 'string',
+        ];
+    }
+
+    /** @return BelongsTo<Plugin, covariant self> */
+    public function plugin(): BelongsTo
+    {
+        return $this->belongsTo(Plugin::class);
+    }
+
+    //endregion
+
+}

--- a/app/Models/WpOrg/PluginTag.php
+++ b/app/Models/WpOrg/PluginTag.php
@@ -3,18 +3,12 @@
 namespace App\Models\WpOrg;
 
 use App\Models\BaseModel;
-use App\Models\Sync\SyncTheme;
-use Carbon\Carbon;
-use Carbon\CarbonImmutable;
 use Illuminate\Database\Eloquent\Concerns\HasUuids;
-use Illuminate\Database\Eloquent\Relations\BelongsTo;
-use Illuminate\Database\Eloquent\Relations\HasMany;
-use Illuminate\Support\Facades\DB;
-use InvalidArgumentException;
+use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 
 /**
  * @property string $id
- * @property string $theme_id
+ * @property string $plugi
  * @property string $slug
  */
 final class PluginTag extends BaseModel
@@ -30,16 +24,23 @@ final class PluginTag extends BaseModel
         return [
             'id' => 'string',
             'slug' => 'string',
-            'plugin_id' => 'string',
+            'name' => 'string',
         ];
-    }
-
-    /** @return BelongsTo<Plugin, covariant self> */
-    public function plugin(): BelongsTo
-    {
-        return $this->belongsTo(Plugin::class);
     }
 
     //endregion
 
+    //region Relationships
+
+    /**
+     * Define the relationship to plugins.
+     *
+     * @return BelongsToMany<Plugin, covariant self>
+     */
+    public function plugins(): BelongsToMany
+    {
+        return $this->belongsToMany(Plugin::class, 'plugin_plugin_tags', 'tag_id', 'plugin_id');
+    }
+
+    //endregion
 }

--- a/app/Models/WpOrg/ThemeTag.php
+++ b/app/Models/WpOrg/ThemeTag.php
@@ -3,13 +3,8 @@
 namespace App\Models\WpOrg;
 
 use App\Models\BaseModel;
-use App\Models\Sync\SyncTheme;
-use Carbon\Carbon;
-use Carbon\CarbonImmutable;
 use Illuminate\Database\Eloquent\Concerns\HasUuids;
-use Illuminate\Database\Eloquent\Relations\BelongsTo;
-use Illuminate\Support\Facades\DB;
-use InvalidArgumentException;
+use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 
 /**
  * @property string $id
@@ -29,16 +24,23 @@ final class ThemeTag extends BaseModel
         return [
             'id' => 'string',
             'slug' => 'string',
-            'theme_id' => 'string',
+            'name' => 'string',
         ];
-    }
-
-    /** @return BelongsTo<Theme, covariant self> */
-    public function theme(): BelongsTo
-    {
-        return $this->belongsTo(Theme::class);
     }
 
     //endregion
 
+    //region Relationships
+
+    /**
+     * Define the relationship to themes.
+     *
+     * @return BelongsToMany<Theme, covariant self>
+     */
+    public function themes(): BelongsToMany
+    {
+        return $this->belongsToMany(Theme::class, 'theme_theme_tags', 'theme_tag_id', 'theme_id');
+    }
+
+    //endregion
 }

--- a/app/Models/WpOrg/ThemeTag.php
+++ b/app/Models/WpOrg/ThemeTag.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace App\Models\WpOrg;
+
+use App\Models\BaseModel;
+use App\Models\Sync\SyncTheme;
+use Carbon\Carbon;
+use Carbon\CarbonImmutable;
+use Illuminate\Database\Eloquent\Concerns\HasUuids;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Support\Facades\DB;
+use InvalidArgumentException;
+
+/**
+ * @property string $id
+ * @property string $theme_id
+ * @property string $slug
+ */
+final class ThemeTag extends BaseModel
+{
+    //region Model Definition
+
+    use HasUuids;
+
+    protected $table = 'theme_tags';
+
+    protected function casts(): array
+    {
+        return [
+            'id' => 'string',
+            'slug' => 'string',
+            'theme_id' => 'string',
+        ];
+    }
+
+    /** @return BelongsTo<Theme, covariant self> */
+    public function theme(): BelongsTo
+    {
+        return $this->belongsTo(Theme::class);
+    }
+
+    //endregion
+
+}

--- a/app/Services/Themes/HotTagsService.php
+++ b/app/Services/Themes/HotTagsService.php
@@ -17,15 +17,15 @@ class HotTagsService
      * }> */
     public function getHotTags(int $count = -1): array
     {
-        $hotTags = ThemeTag::withCount('themes') // Count associated themes for each tag
-            ->orderBy('themes_count', 'desc') // Order by the count of themes in descending order
-            ->limit($count >= 0 ? $count : 100) // Limit to the top 100 tags
-            ->get(['slug', 'name', 'themes_count']) // Select only slug and themes_count
+        $hotTags = ThemeTag::withCount('themes')
+            ->orderBy('themes_count', 'desc')
+            ->limit($count >= 0 ? $count : 100)
+            ->get(['slug', 'name', 'themes_count'])
             ->map(function ($tag) {
                 return [
-                    'name' => (string) $tag->name, // Format name from slug
+                    'name' => (string) $tag->name, 
                     'slug' => (string) $tag->slug,
-                    'count' => (int) $tag->themes_count, // Use themes_count from withCount
+                    'count' => (int) $tag->themes_count, 
                 ];
             });
         return HotTagsResponse::fromCollection($hotTags)->toArray();

--- a/app/Services/Themes/HotTagsService.php
+++ b/app/Services/Themes/HotTagsService.php
@@ -2,82 +2,32 @@
 
 namespace App\Services\Themes;
 
+use App\Data\WpOrg\Themes\HotTagsResponse;
+use App\Models\WpOrg\ThemeTag;
+
 class HotTagsService
 {
-    public const HARDWIRED_RESPONSE = [
-        "custom-menu" => ["name" => "Custom menu", "slug" => "custom-menu", "count" => 11180],
-        "featured-images" => ["name" => "Featured images", "slug" => "featured-images", "count" => 10676],
-        "threaded-comments" => ["name" => "Threaded comments", "slug" => "threaded-comments", "count" => 10388],
-        "translation-ready" => ["name" => "Translation ready", "slug" => "translation-ready", "count" => 10220],
-        "two-columns" => ["name" => "Two columns", "slug" => "two-columns", "count" => 9955],
-        "right-sidebar" => ["name" => "Right sidebar", "slug" => "right-sidebar", "count" => 9642],
-        "custom-background" => ["name" => "Custom background", "slug" => "custom-background", "count" => 9329],
-        "theme-options" => ["name" => "Theme options", "slug" => "theme-options", "count" => 8576],
-        "blog" => ["name" => "Blog", "slug" => "blog", "count" => 8275],
-        "one-column" => ["name" => "One column", "slug" => "one-column", "count" => 7858],
-        "custom-logo" => ["name" => "Custom logo", "slug" => "custom-logo", "count" => 7756],
-        "custom-header" => ["name" => "Custom header", "slug" => "custom-header", "count" => 7386],
-        "full-width-template" => ["name" => "Full width template", "slug" => "full-width-template", "count" => 6822],
-        "custom-colors" => ["name" => "Custom colors", "slug" => "custom-colors", "count" => 6766],
-        "sticky-post" => ["name" => "Sticky post", "slug" => "sticky-post", "count" => 6642],
-        "footer-widgets" => ["name" => "Footer widgets", "slug" => "footer-widgets", "count" => 6258],
-        "editor-style" => ["name" => "Editor style", "slug" => "editor-style", "count" => 5842],
-        "left-sidebar" => ["name" => "Left sidebar", "slug" => "left-sidebar", "count" => 5684],
-        "rtl-language-support" => ["name" => "RTL language support", "slug" => "rtl-language-support", "count" => 4268],
-        "flexible-header" => ["name" => "Flexible header", "slug" => "flexible-header", "count" => 3979],
-        "grid-layout" => ["name" => "Grid layout", "slug" => "grid-layout", "count" => 3807],
-        "portfolio" => ["name" => "Portfolio", "slug" => "portfolio", "count" => 3773],
-        "post-formats" => ["name" => "Post formats", "slug" => "post-formats", "count" => 3644],
-        "e-commerce" => ["name" => "E-commerce", "slug" => "e-commerce", "count" => 3481],
-        "three-columns" => ["name" => "Three columns", "slug" => "three-columns", "count" => 3169],
-        "news" => ["name" => "News", "slug" => "news", "count" => 2519],
-        "wide-blocks" => ["name" => "Wide blocks", "slug" => "wide-blocks", "count" => 2403],
-        "featured-image-header" => ["name" => "Featured image header", "slug" => "featured-image-header", "count" => 2299],
-        "block-styles" => ["name" => "Block editor styles", "slug" => "block-styles", "count" => 2088],
-        "photography" => ["name" => "Photography", "slug" => "photography", "count" => 1473],
-        "entertainment" => ["name" => "Entertainment", "slug" => "entertainment", "count" => 1435],
-        "white" => ["name" => "White", "slug" => "white", "count" => 1312],
-        "four-columns" => ["name" => "Four columns", "slug" => "four-columns", "count" => 1267],
-        "block-patterns" => ["name" => "Block editor patterns", "slug" => "block-patterns", "count" => 1245],
-        "full-site-editing" => ["name" => "Block themes", "slug" => "full-site-editing", "count" => 1057],
-        "light" => ["name" => "Light", "slug" => "light", "count" => 1056],
-        "fixed-width" => ["name" => "Fixed Width", "slug" => "fixed-width", "count" => 1008],
-        "microformats" => ["name" => "Microformats", "slug" => "microformats", "count" => 995],
-        "education" => ["name" => "Education", "slug" => "education", "count" => 856],
-        "blue" => ["name" => "Blue", "slug" => "blue", "count" => 781],
-        "black" => ["name" => "Black", "slug" => "black", "count" => 753],
-        "responsive-layout" => ["name" => "Responsive Layout", "slug" => "responsive-layout", "count" => 699],
-        "food-and-drink" => ["name" => "Food & drink", "slug" => "food-and-drink", "count" => 520],
-        "gray" => ["name" => "Gray", "slug" => "gray", "count" => 465],
-        "green" => ["name" => "Green", "slug" => "green", "count" => 432],
-        "dark" => ["name" => "Dark", "slug" => "dark", "count" => 379],
-        "template-editing" => ["name" => "Template editing", "slug" => "template-editing", "count" => 359],
-        "red" => ["name" => "Red", "slug" => "red", "count" => 356],
-        "fluid-layout" => ["name" => "Fluid Layout", "slug" => "fluid-layout", "count" => 320],
-        "style-variations" => ["name" => "Style variations", "slug" => "style-variations", "count" => 311],
-        "orange" => ["name" => "Orange", "slug" => "orange", "count" => 285],
-        "flexible-width" => ["name" => "Flexible Width", "slug" => "flexible-width", "count" => 257],
-        "accessibility-ready" => ["name" => "Accessibility ready", "slug" => "accessibility-ready", "count" => 250],
-        "brown" => ["name" => "Brown", "slug" => "brown", "count" => 208],
-        "fixed-layout" => ["name" => "Fixed Layout", "slug" => "fixed-layout", "count" => 202],
-        "holiday" => ["name" => "Holiday", "slug" => "holiday", "count" => 197],
-        "yellow" => ["name" => "Yellow", "slug" => "yellow", "count" => 154],
-        "silver" => ["name" => "Silver", "slug" => "silver", "count" => 149],
-        "buddypress" => ["name" => "BuddyPress", "slug" => "buddypress", "count" => 147],
-        "pink" => ["name" => "Pink", "slug" => "pink", "count" => 142],
-        "front-page-post-form" => ["name" => "Front page posting", "slug" => "front-page-post-form", "count" => 133],
-        "purple" => ["name" => "Purple", "slug" => "purple", "count" => 133],
-        "photoblogging" => ["name" => "Photoblogging", "slug" => "photoblogging", "count" => 128],
-        "tan" => ["name" => "Tan", "slug" => "tan", "count" => 99],
-        "seasonal" => ["name" => "Seasonal", "slug" => "seasonal", "count" => 43],
-        "blavatar" => ["name" => "Blavatar", "slug" => "blavatar", "count" => 11],
-        "testing" => ["name" => "testing", "slug" => "testing", "count" => 0],
-        "none" => ["name" => "none", "slug" => "none", "count" => 0],
-    ];
-
-    /** @return array<string, array{name:string, slug:string, count:int}> */
+    /**
+     * Gets the top tags by theme count
+     *
+     * @return array<string, array{
+     *   name: string,
+     *  slug: string,
+     *  count: int,
+     * }> */
     public function getHotTags(int $count = -1): array
     {
-        return $count > 0 ? array_slice(self::HARDWIRED_RESPONSE, 0, $count) : self::HARDWIRED_RESPONSE;
+        $hotTags = ThemeTag::withCount('themes') // Count associated themes for each tag
+            ->orderBy('themes_count', 'desc') // Order by the count of themes in descending order
+            ->limit($count >= 0 ? $count : 100) // Limit to the top 100 tags
+            ->get(['slug', 'name', 'themes_count']) // Select only slug and themes_count
+            ->map(function ($tag) {
+                return [
+                    'name' => (string) $tag->name, // Format name from slug
+                    'slug' => (string) $tag->slug,
+                    'count' => (int) $tag->themes_count, // Use themes_count from withCount
+                ];
+            });
+        return HotTagsResponse::fromCollection($hotTags)->toArray();
     }
 }

--- a/database/migrations/2024_10_30_212232_create_tags_table.php
+++ b/database/migrations/2024_10_30_212232_create_tags_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    public function up(): void
+    {
+        Schema::create('theme_tags', function (Blueprint $table) {
+            $table->uuid('id')->primary();
+            $table->string('slug');    // more or less the user "slug", used in permalinks
+            $table->foreignUuid('theme_id')->references('id')->on('themes');
+            $table->unique(['slug', 'theme_id']);
+        });
+
+
+        Schema::create('plugin_tags', function (Blueprint $table) {
+            $table->uuid('id')->primary();
+            $table->string('slug');    // more or less the user "slug", used in permalinks
+            $table->foreignUuid('plugin_id')->references('id')->on('plugins');
+            $table->unique(['slug', 'plugin_id']);
+        });
+
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('theme_tags');
+        Schema::dropIfExists('plugin_tags');
+    }
+};

--- a/database/migrations/2024_10_30_212232_create_tags_table.php
+++ b/database/migrations/2024_10_30_212232_create_tags_table.php
@@ -7,21 +7,29 @@ use Illuminate\Support\Facades\Schema;
 return new class extends Migration {
     public function up(): void
     {
-        Schema::create('theme_tags', function (Blueprint $table) {
-            $table->uuid('id')->primary();
-            $table->string('slug');    // more or less the user "slug", used in permalinks
-            $table->foreignUuid('theme_id')->references('id')->on('themes');
-            $table->unique(['slug', 'theme_id']);
-        });
-
-
         Schema::create('plugin_tags', function (Blueprint $table) {
             $table->uuid('id')->primary();
-            $table->string('slug');    // more or less the user "slug", used in permalinks
-            $table->foreignUuid('plugin_id')->references('id')->on('plugins');
-            $table->unique(['slug', 'plugin_id']);
+            $table->string('slug')->unique();    // more or less the user "slug", used in permalinks
+            $table->string('name');
         });
 
+        Schema::create('theme_tags', function (Blueprint $table) {
+            $table->uuid('id')->primary();
+            $table->string('slug')->unique();    // more or less the user "slug", used in permalinks
+            $table->string('name');
+        });
+
+        Schema::create('theme_theme_tags', function (Blueprint $table) {
+            $table->foreignUuid('theme_id')->references('id')->on('themes');
+            $table->foreignUuid('theme_tag_id')->references('id')->on('theme_tags');
+            $table->primary(['theme_id', 'theme_tag_id']);  // Composite primary key
+        });
+
+        Schema::create('plugin_plugin_tags', function (Blueprint $table) {
+            $table->foreignUuid('plugin_id')->references('id')->on('plugins');
+            $table->foreignUuid('plugin_tag_id')->references('id')->on('plugin_tags');
+            $table->primary(['plugin_id', 'plugin_tag_id']);  // Composite primary key
+        });
     }
 
     public function down(): void


### PR DESCRIPTION
# Pull Request

## What changed?

Added migration to create two new tables:
* plugin_tags
* theme_tags

Updated command to populate new tables with tags.
Added relationships between new models and existing Plugin/Theme models

Added query to hot_tags endpoint in ThemeController to fetch top 100 tags with counts (matching the WP.org api)




## Why did it change?

Required to implement hot_tags (ordered list of most popular tags)

## Did you fix any specific issues?

https://github.com/aspirepress/AspireCloud/issues/41

## CERTIFICATION

By opening this pull request, I do agree to abide by
the [CODE OF CONDUCT](https://github.com/aspirepress/.github/CODE_OF_CONDUCT.md) and be bound by the terms
of the [Contribution Guidelines](https://github.com/aspirepress/.github/CONTRIBUTING.md) in effect on the date and time
of my contribution as proven by the
revision information in GitHub. I also agree that any previous contributions shall be deemed subject to the terms of the
version in effect on the date and time of this pull request, or any future revisions for pull requests I may submit.
Further, I certify that this work is my own, is original, does not violate the intellectual property of any other person
or entity, and I am not violating any license agreements or contracts I have with any person or entity. Finally, I agree
that this code may be licensed under any license deemed appropraite by AspirePress, including but not
limited to open source, closed source, proprietary or custom licenses, and that such license terms neither violate my
rights or my copyright to this code.