### PR TITLE
fix: tags fields removed and refactor plugin tests

### DIFF
--- a/database/migrations/2024_11_02_211652_remove_tags_json_from_plugins_table.php
+++ b/database/migrations/2024_11_02_211652_remove_tags_json_from_plugins_table.php
@@ -1,0 +1,27 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('plugins', function (Blueprint $table) {
+            $table->dropColumn('tags');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('plugins', function (Blueprint $table) {
+            $table->jsonb('tags')->nullable();
+        });
+    }
+};

--- a/tests/Feature/API/WpOrg/Plugin_1_2_ControllerTest.php
+++ b/tests/Feature/API/WpOrg/Plugin_1_2_ControllerTest.php
@@ -2,24 +2,8 @@
 
 use App\Models\WpOrg\Plugin;
 
-beforeEach(function () {
-    Plugin::factory()->create([
-        'name' => 'JWT Auth',
-        'slug' => 'jwt-auth',
-        'tags' => ['authentication', 'jwt', 'api'],
-    ]);
-
-    Plugin::factory()->create([
-        'name' => 'JWT Authentication for WP-API',
-        'slug' => 'jwt-authentication-for-wp-rest-api',
-        'tags' => ['jwt', 'api', 'rest-api'],
-        'author' => 'tmeister',
-    ]);
-
-    Plugin::factory()->count(8)->create();
-});
-
 it('returns 400 when slug is missing', function () {
+    Plugin::factory(10)->create();
     $response = makeApiRequest('GET', '/plugins/info/1.2?action=plugin_information');
 
     $response->assertStatus(400)
@@ -29,6 +13,7 @@ it('returns 400 when slug is missing', function () {
 });
 
 it('returns 404 when plugin does not exist', function () {
+    Plugin::factory(10)->create();
     $response = makeApiRequest('GET', '/plugins/info/1.2?action=plugin_information&slug=non-existent-plugin');
 
     $response->assertStatus(404)
@@ -38,6 +23,12 @@ it('returns 404 when plugin does not exist', function () {
 });
 
 it('returns plugin information in wp.org format', function () {
+    Plugin::factory()->create([
+        'name' => 'JWT Authentication for WP-API',
+        'slug' => 'jwt-authentication-for-wp-rest-api',
+    ]);
+    Plugin::factory(9)->create();
+
     $response = makeApiRequest('GET', '/plugins/info/1.2?action=plugin_information&slug=jwt-authentication-for-wp-rest-api');
 
     $response->assertStatus(200)
@@ -49,14 +40,15 @@ it('returns plugin information in wp.org format', function () {
 });
 
 it('returns search results by tag in wp.org format', function () {
-    $tag = 'jwt';
+    $tags = ['jwt', 'authentication', 'rest api'];
+    $tagToQuery = 'jwt';
+
+    Plugin::factory(8)->create();
+    Plugin::factory()->count(2)->withSpecificTags($tags)->create();
 
     expect(Plugin::query()->count())->toBe(10);
 
-    $jwtPlugins = Plugin::query()->where('tags', 'ilike', '%' . $tag . '%')->count();
-    expect($jwtPlugins)->toBe(2);
-
-    $response = makeApiRequest('GET', '/plugins/info/1.2?action=query_plugins&tag=' . $tag);
+    $response = makeApiRequest('GET', '/plugins/info/1.2?action=query_plugins&tag=' . $tagToQuery);
 
     $response->assertStatus(200);
     assertWpPluginAPIStructureForSearch($response);
@@ -74,12 +66,19 @@ it('returns search results by tag in wp.org format', function () {
         ->and($responseData['info']['results'])->toBe(2);
 
     foreach ($responseData['plugins'] as $plugin) {
-        expect($plugin['tags'])->toContain($tag);
+        expect($plugin['tags'])->toContain($tagToQuery);
     }
 });
 
 it('returns search results by query string in wp.org format', function () {
     $query = 'jwt';
+    Plugin::factory()->create([
+        'name' => 'JWT Authentication for WP-API',
+        'slug' => 'jwt-authentication-for-wp-rest-api',
+    ]);
+
+    Plugin::factory(9)->create();
+
     expect(Plugin::query()->count())->toBe(10);
 
     $response = makeApiRequest('GET', '/plugins/info/1.2?action=query_plugins&search=' . $query);
@@ -88,7 +87,7 @@ it('returns search results by query string in wp.org format', function () {
     assertWpPluginAPIStructureForSearch($response);
 
     $responseData = $response->json();
-    expect(count($responseData['plugins']))->toBe(2)
+    expect(count($responseData['plugins']))->toBe(1)
         ->and($responseData['info'])->toHaveKeys([
             'page',
             'pages',
@@ -96,16 +95,23 @@ it('returns search results by query string in wp.org format', function () {
         ])
         ->and($responseData['info']['page'])->toBe(1)
         ->and($responseData['info']['pages'])->toBe(1)
-        ->and($responseData['info']['results'])->toBe(2);
+        ->and($responseData['info']['results'])->toBe(1);
 });
 
 it('returns search results by tag and author in wp.org format', function () {
-    $tag = 'jwt';
+    $tags = ['jwt', 'authentication', 'rest api'];
+    $tagToQuery = 'jwt';
     $author = 'tmeister';
+
+    Plugin::factory(9)->create();
+    Plugin::factory()->count(1)
+        ->withSpecificTags($tags)->create([
+                         'author' => $author,
+                     ]);
 
     expect(Plugin::query()->count())->toBe(10);
 
-    $response = makeApiRequest('GET', '/plugins/info/1.2?action=query_plugins&tag=' . $tag . '&author=' . $author);
+    $response = makeApiRequest('GET', '/plugins/info/1.2?action=query_plugins&tag=' . $tagToQuery . '&author=' . $author);
 
     $response->assertStatus(200);
     assertWpPluginAPIStructureForSearch($response);
@@ -126,6 +132,7 @@ it('returns a valid pagination', function () {
     $perPage = 2;
     $page = 2;
 
+    Plugin::factory(10)->create();
     expect(Plugin::query()->count())->toBe(10);
 
     $response = makeApiRequest('GET', '/plugins/info/1.2?action=query_plugins&per_page=' . $perPage . '&page=' . $page);


### PR DESCRIPTION
# Pull Request

## What changed?

- On #87, a many-to-many relationship for tags was introduced; keeping the tags field on the Plugin's table is unnecessary
- Append the tags' relationship to the Plugins via `getTagsAttribute`
- Refactor the Plugin tests to use the new many-to-many relationship
- Refactor the PluginFactory to allow create plugins with the tags relationship

## Why did it change?

To made the tests pass again

## Did you fix any specific issues?

NA

## CERTIFICATION

By opening this pull request, I do agree to abide by
the [CODE OF CONDUCT](https://github.com/aspirepress/.github/CODE_OF_CONDUCT.md) and be bound by the terms
of the [Contribution Guidelines](https://github.com/aspirepress/.github/CONTRIBUTING.md) in effect on the date and time
of my contribution as proven by the
revision information in GitHub. I also agree that any previous contributions shall be deemed subject to the terms of the
version in effect on the date and time of this pull request, or any future revisions for pull requests I may submit.
Further, I certify that this work is my own, is original, does not violate the intellectual property of any other person
or entity, and I am not violating any license agreements or contracts I have with any person or entity. Finally, I agree
that this code may be licensed under any license deemed appropraite by AspirePress, including but not
limited to open source, closed source, proprietary or custom licenses, and that such license terms neither violate my
rights or my copyright to this code.