### PR TITLE
Return rating as is

### DIFF
--- a/app/Http/Resources/ThemeResource.php
+++ b/app/Http/Resources/ThemeResource.php
@@ -68,7 +68,7 @@ class ThemeResource extends JsonResource
             //     return collect(range(1, $screenshotCount))->map(fn($i) => "{$screenshotBase}-{$i}.png");
             // }),
             'ratings' => $this->whenField('ratings', fn() => (object) $resource->ratings),  // need the object cast when all keys are numeric
-            'rating' => $this->whenField('rating', fn() => $resource->rating * 20),
+            'rating' => $this->whenField('rating', fn() => $resource->rating),
             'num_ratings' => $this->whenField('rating', fn() => $resource->num_ratings),
             'reviews_url' => $this->whenField('reviews_url', $resource->reviews_url),
             'downloaded' => $this->whenField('downloaded', fn() => $resource->downloaded),


### PR DESCRIPTION
# Pull Request

## What changed?

Updates the Theme response to return rating directly without multiplying by 20

## Why did it change?

Error thrown when browsing the themes from within WP as it's receiving rating values of > 100. 

Theme is already stored out of 100 (rather than 5) in the DB in both tables, sync_themes and themes. 
Code is now updated to reflect this. 

## Did you fix any specific issues?

## CERTIFICATION

By opening this pull request, I do agree to abide by
the [CODE OF CONDUCT](https://github.com/aspirepress/.github/CODE_OF_CONDUCT.md) and be bound by the terms
of the [Contribution Guidelines](https://github.com/aspirepress/.github/CONTRIBUTING.md) in effect on the date and time
of my contribution as proven by the
revision information in GitHub. I also agree that any previous contributions shall be deemed subject to the terms of the
version in effect on the date and time of this pull request, or any future revisions for pull requests I may submit.
Further, I certify that this work is my own, is original, does not violate the intellectual property of any other person
or entity, and I am not violating any license agreements or contracts I have with any person or entity. Finally, I agree
that this code may be licensed under any license deemed appropraite by AspirePress, including but not
limited to open source, closed source, proprietary or custom licenses, and that such license terms neither violate my
rights or my copyright to this code.