### PR TITLE
add Laravel queue worker service, use events to dispatch jobs

### DIFF
--- a/app/Events/AssetCacheHit.php
+++ b/app/Events/AssetCacheHit.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace App\Events;
+
+use App\Models\WpOrg\Asset;
+use Illuminate\Foundation\Events\Dispatchable;
+
+readonly class AssetCacheHit
+{
+    use Dispatchable;
+
+    public function __construct(public Asset $asset) {}
+}

--- a/app/Events/AssetCacheMissed.php
+++ b/app/Events/AssetCacheMissed.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Events;
+
+use App\Enums\AssetType;
+use Illuminate\Foundation\Events\Dispatchable;
+
+readonly class AssetCacheMissed
+{
+    use Dispatchable;
+
+    public function __construct(
+        public AssetType $type,
+        public string $slug,
+        public string $file,
+        public string $upstreamUrl,
+        public ?string $revision = null,
+    ) {}
+}

--- a/app/Events/AssetCreated.php
+++ b/app/Events/AssetCreated.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace App\Events;
+
+use App\Models\WpOrg\Asset;
+use Illuminate\Foundation\Events\Dispatchable;
+
+readonly class AssetCreated
+{
+    use Dispatchable;
+
+    public function __construct(public Asset $asset) {}
+}

--- a/app/Http/Controllers/API/WpOrg/Downloads/DownloadAssetController.php
+++ b/app/Http/Controllers/API/WpOrg/Downloads/DownloadAssetController.php
@@ -18,14 +18,8 @@ class DownloadAssetController
             ? AssetType::SCREENSHOT
             : AssetType::BANNER;
 
-        // get the revision from the query string if it exists
         $rev = request()->query('rev') ?: null;
 
-        return $this->downloadService->download(
-            $assetType,
-            $slug,
-            $file,
-            $rev
-        );
+        return $this->downloadService->download(type: $assetType, slug: $slug, file: $file, revision: $rev);
     }
 }

--- a/app/Http/Controllers/API/WpOrg/Downloads/DownloadCoreController.php
+++ b/app/Http/Controllers/API/WpOrg/Downloads/DownloadCoreController.php
@@ -21,10 +21,6 @@ class DownloadCoreController extends Controller
 
         $file = "wordpress-{$version}.{$extension}";
 
-        return $this->downloadService->download(
-            AssetType::CORE,
-            'wordpress',
-            $file
-        );
+        return $this->downloadService->download(type: AssetType::CORE, slug: 'wordpress', file: $file);
     }
 }

--- a/app/Http/Controllers/API/WpOrg/Downloads/DownloadPluginController.php
+++ b/app/Http/Controllers/API/WpOrg/Downloads/DownloadPluginController.php
@@ -5,6 +5,7 @@ namespace App\Http\Controllers\API\WpOrg\Downloads;
 use App\Enums\AssetType;
 use App\Http\Controllers\Controller;
 use App\Services\Downloads\DownloadService;
+use App\Utils\Regex;
 use Symfony\Component\HttpFoundation\Response;
 
 class DownloadPluginController extends Controller
@@ -15,11 +16,10 @@ class DownloadPluginController extends Controller
 
     public function __invoke(string $file): Response
     {
-        if (!\Safe\preg_match('/^([a-zA-Z0-9-]+)\.(.+)\.zip$/', $file, $matches)) {
-            return response()->json(['error' => 'Invalid plugin file format'], 400);
+        [,$slug] = Regex::match('/^([a-zA-Z0-9-]+)\.(.+)\.zip$/', $file);
+        if (!$slug) {
+            return response()->json(['error' => "Invalid filename", 'filename' => $file], 400);
         }
-
-        $slug = $matches[1];
 
         return $this->downloadService->download(type: AssetType::PLUGIN, slug: $slug, file: $file);
     }

--- a/app/Http/Controllers/API/WpOrg/Downloads/DownloadPluginController.php
+++ b/app/Http/Controllers/API/WpOrg/Downloads/DownloadPluginController.php
@@ -16,11 +16,11 @@ class DownloadPluginController extends Controller
 
     public function __invoke(string $file): Response
     {
-        [,$slug] = Regex::match('/^([a-zA-Z0-9-]+)\.(.+)\.zip$/', $file);
-        if (!$slug) {
+        $matches = Regex::match('/^([a-zA-Z0-9-]+)\.(.+)\.zip$/', $file);
+        if (!$matches) {
             return response()->json(['error' => "Invalid filename", 'filename' => $file], 400);
         }
 
-        return $this->downloadService->download(type: AssetType::PLUGIN, slug: $slug, file: $file);
+        return $this->downloadService->download(type: AssetType::PLUGIN, slug: $matches[1], file: $file);
     }
 }

--- a/app/Http/Controllers/API/WpOrg/Downloads/DownloadPluginController.php
+++ b/app/Http/Controllers/API/WpOrg/Downloads/DownloadPluginController.php
@@ -21,10 +21,6 @@ class DownloadPluginController extends Controller
 
         $slug = $matches[1];
 
-        return $this->downloadService->download(
-            AssetType::PLUGIN,
-            $slug,
-            $file
-        );
+        return $this->downloadService->download(type: AssetType::PLUGIN, slug: $slug, file: $file);
     }
 }

--- a/app/Http/Controllers/API/WpOrg/Downloads/DownloadThemeController.php
+++ b/app/Http/Controllers/API/WpOrg/Downloads/DownloadThemeController.php
@@ -21,10 +21,6 @@ class DownloadThemeController extends Controller
 
         $slug = $matches[1];
 
-        return $this->downloadService->download(
-            AssetType::THEME,
-            $slug,
-            $file
-        );
+        return $this->downloadService->download(type: AssetType::THEME, slug: $slug, file: $file);
     }
 }

--- a/app/Http/Controllers/API/WpOrg/Downloads/DownloadThemeController.php
+++ b/app/Http/Controllers/API/WpOrg/Downloads/DownloadThemeController.php
@@ -16,11 +16,11 @@ class DownloadThemeController extends Controller
 
     public function __invoke(string $file): Response
     {
-        [,$slug] = Regex::match('/^([a-zA-Z0-9-]+)\.(.+)\.zip$/', $file);
-        if (!$slug) {
+        $matches = Regex::match('/^([a-zA-Z0-9-]+)\.(.+)\.zip$/', $file);
+        if (!$matches) {
             return response()->json(['error' => "Invalid filename", 'filename' => $file], 400);
         }
 
-        return $this->downloadService->download(type: AssetType::THEME, slug: $slug, file: $file);
+        return $this->downloadService->download(type: AssetType::THEME, slug: $matches[1], file: $file);
     }
 }

--- a/app/Http/Controllers/API/WpOrg/Downloads/DownloadThemeController.php
+++ b/app/Http/Controllers/API/WpOrg/Downloads/DownloadThemeController.php
@@ -5,6 +5,7 @@ namespace App\Http\Controllers\API\WpOrg\Downloads;
 use App\Enums\AssetType;
 use App\Http\Controllers\Controller;
 use App\Services\Downloads\DownloadService;
+use App\Utils\Regex;
 use Symfony\Component\HttpFoundation\Response;
 
 class DownloadThemeController extends Controller
@@ -15,11 +16,10 @@ class DownloadThemeController extends Controller
 
     public function __invoke(string $file): Response
     {
-        if (!\Safe\preg_match('/^([a-zA-Z0-9-]+)\.(.+)\.zip$/', $file, $matches)) {
-            return response()->json(['error' => 'Invalid theme file format'], 400);
+        [,$slug] = Regex::match('/^([a-zA-Z0-9-]+)\.(.+)\.zip$/', $file);
+        if (!$slug) {
+            return response()->json(['error' => "Invalid filename", 'filename' => $file], 400);
         }
-
-        $slug = $matches[1];
 
         return $this->downloadService->download(type: AssetType::THEME, slug: $slug, file: $file);
     }

--- a/app/Jobs/DownloadAssetJob.php
+++ b/app/Jobs/DownloadAssetJob.php
@@ -11,7 +11,7 @@ use Illuminate\Queue\InteractsWithQueue;
 use Illuminate\Support\Facades\Http;
 use Illuminate\Support\Facades\Storage;
 
-class DownloadAsset implements ShouldQueue
+class DownloadAssetJob implements ShouldQueue
 {
     use Dispatchable;
     use InteractsWithQueue;

--- a/app/Jobs/DownloadAssetJob.php
+++ b/app/Jobs/DownloadAssetJob.php
@@ -9,6 +9,7 @@ use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Bus\Dispatchable;
 use Illuminate\Queue\InteractsWithQueue;
 use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\Storage;
 
 class DownloadAssetJob implements ShouldQueue
@@ -27,6 +28,9 @@ class DownloadAssetJob implements ShouldQueue
 
     public function handle(): void
     {
+        $revstr = $this->revision ? " rev=$this->revision" : '';
+        Log::info("Downloading asset for {$this->slug}$revstr from $this->upstreamUrl");
+
         $response = Http::withHeaders([
             'User-Agent' => 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36',
             'Accept' => '*/*',
@@ -35,17 +39,17 @@ class DownloadAssetJob implements ShouldQueue
         ])->get($this->upstreamUrl);
 
         if (!$response->successful()) {
+            $status = $response->getStatusCode();
+            $message = $response->getReasonPhrase();
+            $url = $this->upstreamUrl;
+            Log::error("Failed to download asset for {$this->slug}$revstr: $message", compact('status', 'message', 'url'));
             return;
         }
 
-        // Generate a storage path
         $localPath = $this->generateLocalPath();
-
-        // Store the file
         Storage::put($localPath, $response->body());
 
-        // Create or update record
-        Asset::create([
+        $asset = Asset::create([
             'asset_type' => $this->type->value,
             'slug' => $this->slug,
             'version' => $this->extractVersion(),
@@ -53,6 +57,11 @@ class DownloadAssetJob implements ShouldQueue
             'upstream_path' => $this->upstreamUrl,
             'local_path' => $localPath,
         ]);
+
+        Log::info(
+            "Created new Asset $asset->id for {$this->slug}$revstr",
+            ['asset_id' => $asset->id, 'local_path' => $localPath, 'slug' => $this->slug, 'revision' => $this->revision]
+        );
     }
 
     public function generateLocalPath(): string

--- a/app/Jobs/DownloadAssetJob.php
+++ b/app/Jobs/DownloadAssetJob.php
@@ -59,7 +59,7 @@ class DownloadAssetJob implements ShouldQueue
         ]);
 
         Log::info(
-            "Created new Asset $asset->id for {$this->slug}$revstr",
+            "Created new Asset for {$this->slug}$revstr",
             ['asset_id' => $asset->id, 'local_path' => $localPath, 'slug' => $this->slug, 'revision' => $this->revision]
         );
     }

--- a/app/Listeners/DownloadMissedAsset.php
+++ b/app/Listeners/DownloadMissedAsset.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace App\Listeners;
+
+use App\Events\AssetCacheMissed;
+use App\Jobs\DownloadAssetJob;
+use Illuminate\Support\Facades\Log;
+
+class DownloadMissedAsset
+{
+    public function handle(AssetCacheMissed $event): void
+    {
+        Log::debug("Dispatching new DownloadAssetJob", ['event' => $event]);
+
+        dispatch_sync(new DownloadAssetJob(
+            type: $event->type,
+            slug: $event->slug,
+            file: $event->file,
+            upstreamUrl: $event->upstreamUrl,
+            revision: $event->revision
+        ));
+    }
+}

--- a/app/Models/WpOrg/Asset.php
+++ b/app/Models/WpOrg/Asset.php
@@ -3,6 +3,7 @@
 namespace App\Models\WpOrg;
 
 use App\Enums\AssetType;
+use App\Events\AssetCreated;
 use Database\Factories\WpOrg\AssetFactory;
 use Illuminate\Database\Eloquent\Concerns\HasUuids;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
@@ -14,6 +15,10 @@ class Asset extends Model
 
     /** @use HasFactory<AssetFactory> */
     use HasFactory;
+
+    protected $dispatchesEvents = [
+        'created' => AssetCreated::class,
+    ];
 
     protected $fillable = [
         'asset_type',

--- a/app/Models/WpOrg/Asset.php
+++ b/app/Models/WpOrg/Asset.php
@@ -16,6 +16,7 @@ class Asset extends Model
     /** @use HasFactory<AssetFactory> */
     use HasFactory;
 
+    /** @var array<string, class-string> */
     protected $dispatchesEvents = [
         'created' => AssetCreated::class,
     ];

--- a/app/Services/Downloads/DownloadService.php
+++ b/app/Services/Downloads/DownloadService.php
@@ -38,6 +38,7 @@ class DownloadService
         if ($asset && Storage::exists($asset->local_path)) {
             // TODO: handle case where asset exists but local path does not (DownloadAssetJob always creates a new Asset)
             event(new AssetCacheHit($asset));
+            Log::debug("Serving existing asset", ["asset" => $asset]);
             return redirect()->away(
                 Storage::temporaryUrl($asset->local_path, now()->addMinutes(self::TEMPORARY_URL_EXPIRE_MINS)),
             );

--- a/app/Services/Downloads/DownloadService.php
+++ b/app/Services/Downloads/DownloadService.php
@@ -3,7 +3,7 @@
 namespace App\Services\Downloads;
 
 use App\Enums\AssetType;
-use App\Jobs\DownloadAsset;
+use App\Jobs\DownloadAssetJob;
 use App\Models\WpOrg\Asset;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Support\Facades\Storage;
@@ -41,7 +41,7 @@ class DownloadService
         $upstreamUrl = $this->buildUpstreamUrl($type, $slug, $file, $revision);
 
         // Queue the download job and delay it by 10 seconds
-        DownloadAsset::dispatch(
+        DownloadAssetJob::dispatch(
             $type,
             $slug,
             $file,

--- a/app/Services/Downloads/DownloadService.php
+++ b/app/Services/Downloads/DownloadService.php
@@ -11,6 +11,8 @@ use Symfony\Component\HttpFoundation\Response;
 
 class DownloadService
 {
+    public const int TEMPORARY_URL_EXPIRE_MINS = 5;
+
     /**
      * Get the file download response. If the asset exists locally,
      * streams it from storage. Otherwise, proxies the WordPress.org file
@@ -50,19 +52,11 @@ class DownloadService
         return $this->downloadUpstreamFile($upstreamUrl);
     }
 
-    /**
-     * Download a file from our storage
-     * Keep it simple and redirect using a temporary URL
-     */
+    /** Download a file from our storage */
     private function downloadStoredFile(Asset $asset): RedirectResponse
     {
-        $expirationInMinutes = 5;
-
         return redirect()->away(
-            Storage::temporaryUrl(
-                $asset->local_path,
-                now()->addMinutes($expirationInMinutes)
-            )
+            Storage::temporaryUrl($asset->local_path, now()->addMinutes(self::TEMPORARY_URL_EXPIRE_MINS))
         );
     }
 

--- a/app/Utils/Regex.php
+++ b/app/Utils/Regex.php
@@ -4,7 +4,8 @@ namespace App\Utils;
 
 class Regex
 {
-    public static function match($pattern, $subject): array
+    /** @return string[] */
+    public static function match(string $pattern, string $subject): array
     {
         $matches = [];
         \Safe\preg_match($pattern, $subject, $matches);

--- a/app/Utils/Regex.php
+++ b/app/Utils/Regex.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace App\Utils;
+
+class Regex
+{
+    public static function match($pattern, $subject): array
+    {
+        $matches = [];
+        \Safe\preg_match($pattern, $subject, $matches);
+        return $matches;
+    }
+
+    private function __construct()
+    {
+        // not instantiable
+    }
+}

--- a/bin/queue-worker
+++ b/bin/queue-worker
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+exec php artisan queue:work --timeout=60 --tries=5

--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
     "keywords": ["laravel", "framework"],
     "license": "MIT",
     "require": {
-        "php": "^8.2",
+        "php": "^8.3",
         "ext-mbstring": "*",
         "inertiajs/inertia-laravel": "^1.0",
         "laravel/framework": "^11.9",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "a2a90c86949c94676240337411cf556d",
+    "content-hash": "3c3657d5f856d68c8aab25ca454a45d1",
     "packages": [
         {
             "name": "amphp/amp",
@@ -15398,7 +15398,7 @@
     "prefer-stable": true,
     "prefer-lowest": false,
     "platform": {
-        "php": "^8.2",
+        "php": "^8.3",
         "ext-mbstring": "*"
     },
     "platform-dev": [],

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -41,6 +41,19 @@ services:
                 aliases:
                     - 'db.aspiredev.org'
 
+    queue-worker:
+        build:
+            context: .
+            dockerfile: docker/laravel-worker/Dockerfile
+            target: dev
+        entrypoint: [ 'bin/queue-worker' ]
+        restart: unless-stopped
+        volumes:
+            - .:/var/www/html
+        networks:
+            - app-net
+            - aspire-net
+
     cli:
         build:
             context: .

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,73 +1,73 @@
 services:
-  webapp:
-    build:
-      context: .
-      dockerfile: docker/webapp/Dockerfile
-      target: dev
-    ports:
-      - ${LOCAL_HTTP_PORT:-8099}:80
-    volumes:
-      - .:/var/www/html
-    networks:
-      traefik: ~
-      app-net: ~
-      aspire-net:
-        aliases:
-          - 'api.aspiredev.org'
-    labels:
-      - "traefik.enable=true"
-      - "traefik.http.routers.ap-api.rule=Host(`api.aspiredev.org`)"
-      - "traefik.http.routers.ap-api-https.rule=Host(`api.aspiredev.org`)"
-      - "traefik.http.routers.ap-api-https.tls=true"
+    webapp:
+        build:
+            context: .
+            dockerfile: docker/webapp/Dockerfile
+            target: dev
+        ports:
+            - ${LOCAL_HTTP_PORT:-8099}:80
+        volumes:
+            - .:/var/www/html
+        networks:
+            traefik: ~
+            app-net: ~
+            aspire-net:
+                aliases:
+                    - 'api.aspiredev.org'
+        labels:
+            - "traefik.enable=true"
+            - "traefik.http.routers.ap-api.rule=Host(`api.aspiredev.org`)"
+            - "traefik.http.routers.ap-api-https.rule=Host(`api.aspiredev.org`)"
+            - "traefik.http.routers.ap-api-https.tls=true"
 
-  redis:
-    image: redis:latest
-    networks:
-      - app-net
+    redis:
+        image: redis:latest
+        networks:
+            - app-net
 
-  postgres:
-    image: postgres:latest
-    environment:
-      - POSTGRES_PASSWORD=password
-      - PGDATA=/opt/pgdata
-      - POSTGRES_DB=aspirecloud
-    ports:
-      - "${LOCAL_POSTGRES_PORT:-5432}:5432"
-    volumes:
-      - postgresdata:/opt/pgdata
-    networks:
-      app-net: ~
-      aspire-net:
-        aliases:
-          - 'db.aspiredev.org'
+    postgres:
+        image: postgres:latest
+        environment:
+            - POSTGRES_PASSWORD=password
+            - PGDATA=/opt/pgdata
+            - POSTGRES_DB=aspirecloud
+        ports:
+            - "${LOCAL_POSTGRES_PORT:-5432}:5432"
+        volumes:
+            - postgresdata:/opt/pgdata
+        networks:
+            app-net: ~
+            aspire-net:
+                aliases:
+                    - 'db.aspiredev.org'
 
-  cli:
-    build:
-      context: .
-      dockerfile: docker/cli/Dockerfile
-      target: dev
-    volumes:
-      - .:/var/www/html
-    networks:
-      - app-net
-      - aspire-net
+    cli:
+        build:
+            context: .
+            dockerfile: docker/cli/Dockerfile
+            target: dev
+        volumes:
+            - .:/var/www/html
+        networks:
+            - app-net
+            - aspire-net
 
-  mailhog:
-    restart: on-failure
-    image: mailhog/mailhog
-    entrypoint: [ "/bin/sh", "-c", "MailHog >/dev/null 2>&1" ] # mailhog's logging is spammy and useless
-    ports:
-      - "${LOCAL_MAILHOG_UI_PORT:-8525}:8025"
-    networks:
-      - app-net
-      - aspire-net
+    mailhog:
+        restart: on-failure
+        image: mailhog/mailhog
+        entrypoint: [ "/bin/sh", "-c", "MailHog >/dev/null 2>&1" ] # mailhog's logging is spammy and useless
+        ports:
+            - "${LOCAL_MAILHOG_UI_PORT:-8525}:8025"
+        networks:
+            - app-net
+            - aspire-net
 
 networks:
-  app-net: ~
-  aspire-net:
-    external: true
-  traefik:
-    external: true
+    app-net: ~
+    aspire-net:
+        external: true
+    traefik:
+        external: true
 
 volumes:
-  postgresdata: ~
+    postgresdata: ~

--- a/docker/laravel-worker/Dockerfile
+++ b/docker/laravel-worker/Dockerfile
@@ -1,0 +1,28 @@
+FROM php:8.3-cli AS base
+
+COPY --from=composer:2.7 /usr/bin/composer /usr/bin/composer
+ADD --chmod=0755 https://github.com/mlocati/docker-php-extension-installer/releases/download/2.5.2/install-php-extensions /usr/local/bin/
+
+RUN apt update && apt install -y bash git postgresql-client zip
+
+RUN install-php-extensions pdo pdo_pgsql zip intl redis
+
+COPY ./docker/cli/php.ini /usr/local/etc/php/php.ini
+
+WORKDIR /var/www/html
+
+################
+FROM base AS dev
+
+# Xdebug exists, but is explicitly disabled on workers.  Use docker-compose.override.yml to enable.
+RUN install-php-extensions xdebug
+RUN sed -i 's/^/#/' /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini
+
+################
+FROM base AS prod
+
+# TODO: use an external volume
+COPY . /var/www/html
+
+RUN composer install --no-dev --no-interaction --no-progress --working-dir=/var/www/html
+

--- a/docker/laravel-worker/php.ini
+++ b/docker/laravel-worker/php.ini
@@ -1,0 +1,5 @@
+error_reporting=E_ALL & ~E_DEPRECATED
+
+[xdebug]
+xdebug.client_host=host.docker.internal
+xdebug.mode=develop

--- a/tests/Feature/Listeners/DownloadMissedAssetTest.php
+++ b/tests/Feature/Listeners/DownloadMissedAssetTest.php
@@ -1,7 +1,0 @@
-<?php
-
-test('example', function () {
-    $response = $this->get('/');
-
-    $response->assertStatus(200);
-});

--- a/tests/Feature/Listeners/DownloadMissedAssetTest.php
+++ b/tests/Feature/Listeners/DownloadMissedAssetTest.php
@@ -1,0 +1,7 @@
+<?php
+
+test('example', function () {
+    $response = $this->get('/');
+
+    $response->assertStatus(200);
+});


### PR DESCRIPTION
# Pull Request

## What changed?

* Adds the `queue-worker` service to the docker-compose stack, which processes the job queue
* Uses events to dispatch the download job, since events are easy to instrument.

## Why did it change?

So we can run actual background jobs.

## Did you fix any specific issues?

none

## CERTIFICATION

By opening this pull request, I do agree to abide by the [CODE OF CONDUCT](https://github.com/aspirepress/.github/CODE_OF_CONDUCT.md) and be bound by the terms of the [Contribution Guidelines](https://github.com/aspirepress/.github/CONTRIBUTING.md) in effect on the date and time of my contribution as proven by the revision information in GitHub. I also agree that any previous contributions shall be deemed subject to the terms of the ersion in effect on the date and time of this pull request, or any future revisions for pull requests I may submit.

Further, I certify that this work is my own, is original, does not violate the intellectual property of any other person or entity, and I am not violating any license agreements or contracts I have with any person or entity. Finally, I agree that this code may be licensed under any license deemed appropriate by AspirePress, including but not limited to open source, closed source, proprietary or custom licenses, and that such license terms neither violate my rights or my copyright to this code.
