### PR TITLE
Disable CacheApiResponse middleware, use 5m cache for the CDN

### DIFF
--- a/app/Http/Middleware/CacheApiResponse.php
+++ b/app/Http/Middleware/CacheApiResponse.php
@@ -1,5 +1,7 @@
 <?php
 
+// Note: not currently used.  Update endpoints cannot have long cache periods, and the WordPres UA doesn't cache anyway.
+
 namespace App\Http\Middleware;
 
 use Closure;
@@ -32,12 +34,13 @@ class CacheApiResponse
             'stale-while-revalidate' => 86400,  // 24 hours
             'public' => true,
         ],
-        'POST' => [
-            'max-age' => 300,                   // 5 minutes
-            's-maxage' => 3600,                 // 1 hour for CDN
-            'stale-while-revalidate' => 7200,   // 2 hours
-            'public' => true,
-        ],
+        // POST responses must _never_ be cached
+        // 'POST' => [
+        //     'max-age' => 300,                   // 5 minutes
+        //     's-maxage' => 3600,                 // 1 hour for CDN
+        //     'stale-while-revalidate' => 7200,   // 2 hours
+        //     'public' => true,
+        // ],
     ];
 
     public function handle(Request $request, Closure $next): Response

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -1,6 +1,5 @@
 <?php
 
-use App\Http\Middleware\CacheApiResponse;
 use App\Http\Middleware\TrustProxies;
 use Illuminate\Auth\AuthenticationException;
 use Illuminate\Cookie\Middleware\AddQueuedCookiesToResponse;
@@ -49,7 +48,7 @@ return Application::configure(basePath: dirname(__DIR__))
             // \Laravel\Sanctum\Http\Middleware\EnsureFrontendRequestsAreStateful::class,
             // 'throttle:api',
             SubstituteBindings::class,
-            CacheApiResponse::class
+            // CacheApiResponse::class // replaced with laravels cache.headers in api.php
         ]);
     })
     ->withExceptions(function (Exceptions $exceptions) use ($apiPaths) {

--- a/routes/api.php
+++ b/routes/api.php
@@ -19,7 +19,10 @@ use Illuminate\Support\Facades\Route;
 
 // https://codex.wordpress.org/WordPress.org_API
 
-$middlewares = [NormalizeWpOrgRequest::class];
+$middlewares = [
+    NormalizeWpOrgRequest::class,
+    'cache.headers:public;max_age=300,etag', // for the CDN's benefit: the WP user agent does not cache at all.
+];
 $routeDefinition = Route::prefix('/');
 
 if (config('app.aspire_press.api_authentication_enable')) {

--- a/tests/Feature/API/WpOrg/ApiCachingTest.php
+++ b/tests/Feature/API/WpOrg/ApiCachingTest.php
@@ -1,140 +1,140 @@
 <?php
 
-use App\Models\WpOrg\Plugin;
+test('disabled test')->skip('cache middleware is not being used');
 
-describe('HTTP Cache Middleware', function () {
-    beforeEach(function () {
-        // Create some test plugins
-        Plugin::factory(2)->create();
-    });
-
-    it('adds cache headers for plugin query endpoint', function () {
-        $response = makeApiRequest('GET', '/plugins/info/1.2?action=query_plugins');
-
-        expect($response->getStatusCode())->toBe(200)
-            ->and($response->headers->has('ETag'))->toBeTrue()
-            ->and($response->headers->has('Cache-Control'))->toBeTrue()
-            ->and($response->headers->get('Cache-Control'))->toContain('public')
-            ->and($response->headers->get('Cache-Control'))->toContain('max-age=3600')
-            ->and($response->headers->get('Cache-Control'))->toContain('s-maxage=21600')
-            ->and($response->headers->get('Vary'))->toBe('Accept-Encoding');
-    });
-
-    it('returns 304 when ETag matches', function () {
-        // First request to get the ETag
-        $firstResponse = makeApiRequest('GET', '/plugins/info/1.2?action=query_plugins');
-        $etag = $firstResponse->headers->get('ETag');
-
-        // Second request with the ETag
-        $secondResponse = makeApiRequest('GET', '/plugins/info/1.2?action=query_plugins', [], [
-            'If-None-Match' => $etag,
-        ]);
-
-        expect($secondResponse->getStatusCode())->toBe(304)
-            ->and($secondResponse->headers->get('ETag'))->toBe($etag);
-    });
-
-    it('generates different ETags for different query parameters', function () {
-        $response1 = makeApiRequest('GET', '/plugins/info/1.2?action=query_plugins&page=1');
-        $response2 = makeApiRequest('GET', '/plugins/info/1.2?action=query_plugins&page=2');
-
-        expect($response1->headers->get('ETag'))
-            ->not->toBe($response2->headers->get('ETag'));
-    });
-
-    it('uses different cache settings for POST requests', function () {
-        $response = makeApiRequest('POST', '/plugins/update-check/1.1', [
-            'plugins' => [
-                'test-plugin/test.php' => [
-                    'Version' => '1.0',
-                ],
-            ],
-        ]);
-
-        expect($response->headers->get('Cache-Control'))->toContain('max-age=300')
-            ->and($response->headers->get('Cache-Control'))->toContain('s-maxage=3600');
-    });
-
-    it('excludes specified routes from caching', function () {
-        $response = makeApiRequest('GET', '/secret-key/1.0');
-
-        expect($response->headers->has('ETag'))->toBeFalse()
-            ->and($response->headers->has('Cache-Control'))->toBeFalse();
-    });
-
-    it('maintains same ETag for identical requests', function () {
-        $response1 = makeApiRequest('GET', '/plugins/info/1.2?action=query_plugins');
-        $response2 = makeApiRequest('GET', '/plugins/info/1.2?action=query_plugins');
-
-        expect($response1->headers->get('ETag'))
-            ->toBe($response2->headers->get('ETag'));
-    });
-
-    it('generates same ETag regardless of parameter order', function () {
-        $response1 = makeApiRequest('GET', '/plugins/info/1.2?action=query_plugins&page=1');
-        $response2 = makeApiRequest('GET', '/plugins/info/1.2?page=1&action=query_plugins');
-
-        expect($response1->headers->get('ETag'))
-            ->toBe($response2->headers->get('ETag'));
-    });
-});
-
-// Test real-world API endpoints
-describe('API Endpoints Cache Behavior', function () {
-    beforeEach(function () {
-        Plugin::factory(3)->create();
-    });
-
-    it('caches plugin info endpoint correctly', function () {
-        Plugin::factory()->create(['slug' => 'test-plugin']);
-        // First request
-        $response1 = makeApiRequest('GET', '/plugins/info/1.2?action=plugin_information&slug=test-plugin');
-        $etag1 = $response1->headers->get('ETag');
-
-        expect($response1->getStatusCode())->toBe(200)
-            ->and($etag1)->not->toBeNull()
-            ->and($response1->headers->get('Cache-Control'))->toContain('public')
-            ->and($response1->headers->get('Cache-Control'))->toContain('max-age=3600');
-
-        // Second request with ETag
-        $response2 = makeApiRequest('GET', '/plugins/info/1.2?action=plugin_information&slug=test-plugin', [], [
-            'If-None-Match' => $etag1,
-        ]);
-
-        expect($response2->getStatusCode())->toBe(304);
-    });
-
-    it('caches plugin query endpoint correctly', function () {
-        // First request
-        $response1 = makeApiRequest('GET', '/plugins/info/1.2?action=query_plugins&page=1');
-
-        expect($response1->getStatusCode())->toBe(200)
-            ->and($response1->json())->toHaveKey('plugins')
-            ->and(count($response1->json()['plugins']))->toBe(3);
-
-        $etag1 = $response1->headers->get('ETag');
-
-        // Second request with ETag
-        $response2 = makeApiRequest('GET', '/plugins/info/1.2?action=query_plugins&page=1', [], [
-            'If-None-Match' => $etag1,
-        ]);
-
-        expect($response2->getStatusCode())->toBe(304);
-    });
-
-    it('generates new ETag when plugin data changes', function () {
-        // Initial request
-        $response1 = makeApiRequest('GET', '/plugins/info/1.2?action=query_plugins');
-        $etag1 = $response1->headers->get('ETag');
-
-        // Create a new plugin
-        Plugin::factory()->create();
-
-        // Second request
-        $response2 = makeApiRequest('GET', '/plugins/info/1.2?action=query_plugins');
-        $etag2 = $response2->headers->get('ETag');
-
-        expect($etag1)->not->toBe($etag2)
-            ->and(count($response2->json()['plugins']))->toBe(4);
-    });
-});
+// describe('HTTP Cache Middleware', function () {
+//     beforeEach(function () {
+//         // Create some test plugins
+//         Plugin::factory(2)->create();
+//     });
+//
+//     it('adds cache headers for plugin query endpoint', function () {
+//         $response = makeApiRequest('GET', '/plugins/info/1.2?action=query_plugins');
+//
+//         expect($response->getStatusCode())->toBe(200)
+//             ->and($response->headers->has('ETag'))->toBeTrue()
+//             ->and($response->headers->has('Cache-Control'))->toBeTrue()
+//             ->and($response->headers->get('Cache-Control'))->toContain('public')
+//             ->and($response->headers->get('Cache-Control'))->toContain('max-age=3600')
+//             ->and($response->headers->get('Cache-Control'))->toContain('s-maxage=21600')
+//             ->and($response->headers->get('Vary'))->toBe('Accept-Encoding');
+//     });
+//
+//     it('returns 304 when ETag matches', function () {
+//         // First request to get the ETag
+//         $firstResponse = makeApiRequest('GET', '/plugins/info/1.2?action=query_plugins');
+//         $etag = $firstResponse->headers->get('ETag');
+//
+//         // Second request with the ETag
+//         $secondResponse = makeApiRequest('GET', '/plugins/info/1.2?action=query_plugins', [], [
+//             'If-None-Match' => $etag,
+//         ]);
+//
+//         expect($secondResponse->getStatusCode())->toBe(304)
+//             ->and($secondResponse->headers->get('ETag'))->toBe($etag);
+//     });
+//
+//     it('generates different ETags for different query parameters', function () {
+//         $response1 = makeApiRequest('GET', '/plugins/info/1.2?action=query_plugins&page=1');
+//         $response2 = makeApiRequest('GET', '/plugins/info/1.2?action=query_plugins&page=2');
+//
+//         expect($response1->headers->get('ETag'))
+//             ->not->toBe($response2->headers->get('ETag'));
+//     });
+//
+//     it('uses different cache settings for POST requests', function () {
+//         $response = makeApiRequest('POST', '/plugins/update-check/1.1', [
+//             'plugins' => [
+//                 'test-plugin/test.php' => [
+//                     'Version' => '1.0',
+//                 ],
+//             ],
+//         ]);
+//
+//         expect($response->headers->get('Cache-Control'))->toContain('max-age=300')
+//             ->and($response->headers->get('Cache-Control'))->toContain('s-maxage=3600');
+//     });
+//
+//     it('excludes specified routes from caching', function () {
+//         $response = makeApiRequest('GET', '/secret-key/1.0');
+//
+//         expect($response->headers->has('ETag'))->toBeFalse()
+//             ->and($response->headers->has('Cache-Control'))->toBeFalse();
+//     });
+//
+//     it('maintains same ETag for identical requests', function () {
+//         $response1 = makeApiRequest('GET', '/plugins/info/1.2?action=query_plugins');
+//         $response2 = makeApiRequest('GET', '/plugins/info/1.2?action=query_plugins');
+//
+//         expect($response1->headers->get('ETag'))
+//             ->toBe($response2->headers->get('ETag'));
+//     });
+//
+//     it('generates same ETag regardless of parameter order', function () {
+//         $response1 = makeApiRequest('GET', '/plugins/info/1.2?action=query_plugins&page=1');
+//         $response2 = makeApiRequest('GET', '/plugins/info/1.2?page=1&action=query_plugins');
+//
+//         expect($response1->headers->get('ETag'))
+//             ->toBe($response2->headers->get('ETag'));
+//     });
+// });
+//
+// // Test real-world API endpoints
+// describe('API Endpoints Cache Behavior', function () {
+//     beforeEach(function () {
+//         Plugin::factory(3)->create();
+//     });
+//
+//     it('caches plugin info endpoint correctly', function () {
+//         Plugin::factory()->create(['slug' => 'test-plugin']);
+//         // First request
+//         $response1 = makeApiRequest('GET', '/plugins/info/1.2?action=plugin_information&slug=test-plugin');
+//         $etag1 = $response1->headers->get('ETag');
+//
+//         expect($response1->getStatusCode())->toBe(200)
+//             ->and($etag1)->not->toBeNull()
+//             ->and($response1->headers->get('Cache-Control'))->toContain('public')
+//             ->and($response1->headers->get('Cache-Control'))->toContain('max-age=3600');
+//
+//         // Second request with ETag
+//         $response2 = makeApiRequest('GET', '/plugins/info/1.2?action=plugin_information&slug=test-plugin', [], [
+//             'If-None-Match' => $etag1,
+//         ]);
+//
+//         expect($response2->getStatusCode())->toBe(304);
+//     });
+//
+//     it('caches plugin query endpoint correctly', function () {
+//         // First request
+//         $response1 = makeApiRequest('GET', '/plugins/info/1.2?action=query_plugins&page=1');
+//
+//         expect($response1->getStatusCode())->toBe(200)
+//             ->and($response1->json())->toHaveKey('plugins')
+//             ->and(count($response1->json()['plugins']))->toBe(3);
+//
+//         $etag1 = $response1->headers->get('ETag');
+//
+//         // Second request with ETag
+//         $response2 = makeApiRequest('GET', '/plugins/info/1.2?action=query_plugins&page=1', [], [
+//             'If-None-Match' => $etag1,
+//         ]);
+//
+//         expect($response2->getStatusCode())->toBe(304);
+//     });
+//
+//     it('generates new ETag when plugin data changes', function () {
+//         // Initial request
+//         $response1 = makeApiRequest('GET', '/plugins/info/1.2?action=query_plugins');
+//         $etag1 = $response1->headers->get('ETag');
+//
+//         // Create a new plugin
+//         Plugin::factory()->create();
+//
+//         // Second request
+//         $response2 = makeApiRequest('GET', '/plugins/info/1.2?action=query_plugins');
+//         $etag2 = $response2->headers->get('ETag');
+//
+//         expect($etag1)->not->toBe($etag2)
+//             ->and(count($response2->json()['plugins']))->toBe(4);
+//     });
+// })


### PR DESCRIPTION
# Pull Request

## What changed?

The CacheApiResponse middleware has been disabled, and Laravel's built-in `cache.headers` middleware used instead, using a short TTL of five minutes, plus etags.   I'd originally asked for the middleware largely to prevent excessive requests to .org, but on further reflection it's more or less redundant with built-in functionality.

## Why did it change?

Several reasons:

* Responses to POST were being cached, which cannot ever happen.  That would make everybody get the same response to plugin/theme update queries.
* Laravel's built-in cache.headers middleware is sufficiently expressive for our needs.
* The WordPress UA doesn't cache anything anyway, this only affects the CDN. A 5m expiration should be enough to offload request volume during spikes without causing major inconsistencies on distributed sites.  We can always bump it up later if we have to.

## Did you fix any specific issues?

none

## CERTIFICATION

By opening this pull request, I do agree to abide by the [Code of Conduct](https://github.com/aspirepress/.github/blob/updating-contributor-policy/CODE_OF_CONDUCT.md) and be bound by the terms of the [Contribution Guidelines](https://github.com/aspirepress/.github/blob/updating-contributor-policy/CONTRIBUTING.md) in effect on the date and time of my contribution as proven by the revision information in GitHub.

