### PR TITLE
fix: set docker build platform to linux/arm64

### DIFF
--- a/.github/workflows/build-container-images.yaml
+++ b/.github/workflows/build-container-images.yaml
@@ -49,6 +49,7 @@ jobs:
         with:
           context: .
           target: prod
+          platforms: 'linux/arm64'
           file: ${{ matrix.dockerfile }}
           push: true
           tags: ${{ steps.meta.outputs.tags }}


### PR DESCRIPTION
# Pull Request

## What changed?

builds linux/arm64 docker images instead of the default of linux/amd64

## Why did it change?

production is on arm64

## Did you fix any specific issues?

none

## CERTIFICATION

By opening this pull request, I do agree to abide by the [Code of Conduct](https://github.com/aspirepress/.github/blob/updating-contributor-policy/CODE_OF_CONDUCT.md) and be bound by the terms of the [Contribution Guidelines](https://github.com/aspirepress/.github/blob/updating-contributor-policy/CONTRIBUTING.md) in effect on the date and time of my contribution as proven by the revision information in GitHub.

