### PR TITLE
switch to local scripts for container image management

### DIFF
--- a/.github/workflows/build-container-images.yaml
+++ b/.github/workflows/build-container-images.yaml
@@ -3,7 +3,7 @@ name: Build container images
 
 on:
   push:
-    branches: ['main']
+#    branches: ['main']
     tags: ['*']
 #  release:
 #    types: ['published']
@@ -29,6 +29,9 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+
+      - name: Expose GitHub Runtime
+        uses: crazy-max/ghaction-github-runtime@v3
 
       - name: Log in to the GitHub Container Registry
         uses: docker/login-action@65b78e6e13532edd9afa3aa52ac7964289d1a9c1
@@ -62,10 +65,13 @@ jobs:
       - name: Build the Docker image
         run: |
           docker buildx create --use
-          docker buildx build --platform linux/arm64 \
+          docker buildx build \
+            --platform linux/arm64 \
             -f ${{ matrix.dockerfile }} \
             $(for tag in $(echo "$DOCKER_METADATA_OUTPUT_TAGS" | xargs); do echo " -t $tag"; done) \
             --push \
+            --cache-from gha \
+            --cache-to gha,mode=max \
             .
 
 # Attestation action doesn't work with our manual buildx step

--- a/.github/workflows/build-container-images.yaml
+++ b/.github/workflows/build-container-images.yaml
@@ -70,8 +70,8 @@ jobs:
             -f ${{ matrix.dockerfile }} \
             $(for tag in $(echo "$DOCKER_METADATA_OUTPUT_TAGS" | xargs); do echo " -t $tag"; done) \
             --push \
-            --cache-from gha \
-            --cache-to gha,mode=max \
+            --cache-from type=gha \
+            --cache-to type=gha,mode=max \
             .
 
 # Attestation action doesn't work with our manual buildx step

--- a/.github/workflows/build-container-images.yaml
+++ b/.github/workflows/build-container-images.yaml
@@ -1,10 +1,15 @@
 # https://docs.github.com/en/actions/use-cases-and-examples/publishing-packages/publishing-docker-images
 name: Build container images
 
+# Due to the need to cross-build the image for arm64 and the cache not working, this action is SLOW (15m+)
+# Because of this, we're using a local build/push process, and leaving this action only manually triggered.
+
 on:
-  push:
+  workflow_dispatch: ~
+
+#  push:
 #    branches: ['main']
-    tags: ['*']
+#    tags: ['*']
 #  release:
 #    types: ['published']
 

--- a/meta/bin/build-images
+++ b/meta/bin/build-images
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+. $(dirname $0)/prelude.bash
+
+tag=${TAG:-$(git describe --tags --abbrev=0)}
+platform=${PLATFORM:-linux/arm64} # prod is always arm64
+
+if [[ -n $GHCR_TOKEN ]]; then
+    echo $GHCR_TOKEN | docker login ghcr.io -u userame-is-ignored --password-stdin
+    push_arg='--push'
+fi
+
+buildx() {
+    local file=$1
+    local name=$2
+    local tag=$3
+    docker buildx build --platform $PLATFORM -f $file --target prod -t ghcr.io/$name:$tag -t ghcr.io/$name:latest $push_arg .
+}
+
+buildx docker/webapp/Dockerfile aspirepress/aspirecloud $tag
+buildx docker/laravel-worker/Dockerfile aspirepress/aspirecloud-worker $tag

--- a/meta/bin/build-images
+++ b/meta/bin/build-images
@@ -14,7 +14,7 @@ buildx() {
     local file=$1
     local name=$2
     local tag=$3
-    docker buildx build --platform $PLATFORM -f $file --target prod -t ghcr.io/$name:$tag -t ghcr.io/$name:latest $push_arg .
+    docker buildx build --platform $platform -f $file --target prod -t ghcr.io/$name:$tag -t ghcr.io/$name:latest $push_arg .
 }
 
 buildx docker/webapp/Dockerfile aspirepress/aspirecloud $tag

--- a/meta/bin/prelude.bash
+++ b/meta/bin/prelude.bash
@@ -1,0 +1,22 @@
+# This file should be sourced, not run
+[[ -n $TRACE ]] && [[ $TRACE != 0 ]] && set -x
+
+set -o errexit
+
+cd $(dirname $0)/../..
+base=$(pwd)
+
+function warn {
+    echo "$@" >&2
+}
+
+function die() {
+    warn "$@"
+    exit 1
+}
+
+function RUN() {
+  [[ -n $DRY_RUN ]] && [[ $DRY_RUN != 0 ]] && _run=echo
+  $_run "$@"
+}
+


### PR DESCRIPTION
# Pull Request

## What changed?

* The workflow in build-container-images.yaml can now only be triggered manually
* Local scripts in meta/bin can build and upload a container image directly to GHCR

## Why did it change?

The build images need to be linux/arm64, but all the free runners are still amd64, the cross-build takes _ages_, and attempts to use the github cache were to no avail.  We don't need to burn up all our CI minutes with this.

## Did you fix any specific issues?

none

## CERTIFICATION

By opening this pull request, I do agree to abide by the [Code of Conduct](https://github.com/aspirepress/.github/blob/updating-contributor-policy/CODE_OF_CONDUCT.md) and be bound by the terms of the [Contribution Guidelines](https://github.com/aspirepress/.github/blob/updating-contributor-policy/CONTRIBUTING.md) in effect on the date and time of my contribution as proven by the revision information in GitHub.

