### PR TITLE
infra: switch deployment image tag from latest to specific tag (0.7)

### DIFF
--- a/meta/kube/deployment.yaml
+++ b/meta/kube/deployment.yaml
@@ -93,7 +93,7 @@ data:
   API_AUTHENTICATION_ENABLED: "true"
 
   APP_NAME: "aspirecloud"
-  APP_URL: "api.aspirecloud.io"
+  APP_URL: "https://api.aspirecloud.io"
   APP_ENV: "production"
   APP_KEY: "base64:3B+wIIOAiiQ61++I6lqwPcjYZ3PZmqskdHJUpYFbfjU="
   LOG_CHANNEL: "stack"
@@ -120,7 +120,7 @@ data:
   CACHE_STORE: "redis"
   CACHE_PREFIX: ""
 
-  REDIS_CLIENT: "phpredis"
+  REDIS_CLIENT: "predis"
   REDIS_HOST: "redis-master.aspirepress.svc.cluster.local"
   REDIS_PORT: "6379"
 

--- a/meta/kube/deployment.yaml
+++ b/meta/kube/deployment.yaml
@@ -17,8 +17,9 @@ spec:
     spec:
       restartPolicy: Always
       containers:
-        - image: 'ghcr.io/aspirepress/aspirecloud:0.7'
-          name: ac-webapp
+        # when updating the image tag, make sure to update ac-queue-worker too!
+        - name: ac-webapp
+          image: 'ghcr.io/aspirepress/aspirecloud:0.7'
           envFrom:
             - configMapRef:
                 name: ac-configmap
@@ -49,9 +50,10 @@ spec:
     spec:
       restartPolicy: Always
       containers:
+        # when updating the image tag, make sure to update ac-webapp too!
         - name: queue-worker
+          image: 'ghcr.io/aspirepress/aspirecloud-worker:0.7'
           command: [ 'bin/queue-worker' ]
-          image: 'ghcr.io/aspirepress/aspirecloud-worker:latest'
           envFrom:
             - configMapRef:
                 name: ac-configmap

--- a/meta/kube/deployment.yaml
+++ b/meta/kube/deployment.yaml
@@ -17,7 +17,7 @@ spec:
     spec:
       restartPolicy: Always
       containers:
-      - image: 'ghcr.io/aspirepress/aspirecloud:latest'
+        - image: 'ghcr.io/aspirepress/aspirecloud:0.7'
         name: ac-webapp
         envFrom:
           - configMapRef:

--- a/meta/kube/deployment.yaml
+++ b/meta/kube/deployment.yaml
@@ -18,15 +18,15 @@ spec:
       restartPolicy: Always
       containers:
         - image: 'ghcr.io/aspirepress/aspirecloud:0.7'
-        name: ac-webapp
-        envFrom:
-          - configMapRef:
-              name: ac-configmap
-          - secretRef:
-              name: ac-secrets
-        ports:
-        - containerPort: 80
-          protocol: TCP
+          name: ac-webapp
+          envFrom:
+            - configMapRef:
+                name: ac-configmap
+            - secretRef:
+                name: ac-secrets
+          ports:
+            - containerPort: 80
+              protocol: TCP
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -50,7 +50,7 @@ spec:
       restartPolicy: Always
       containers:
         - name: queue-worker
-          command: ['bin/queue-worker']
+          command: [ 'bin/queue-worker' ]
           image: 'ghcr.io/aspirepress/aspirecloud-worker:latest'
           envFrom:
             - configMapRef:
@@ -78,11 +78,11 @@ spec:
   entryPoints:
     - websecure
   routes:
-  - kind: Rule
-    match: Host(`api.aspirecloud.io`)
-    services:
-    - name: ac-webapp
-      port: 80
+    - kind: Rule
+      match: Host(`api.aspirecloud.io`)
+      services:
+        - name: ac-webapp
+          port: 80
 ---
 apiVersion: v1
 kind: ConfigMap
@@ -124,14 +124,14 @@ data:
   REDIS_HOST: "redis-master.aspirepress.svc.cluster.local"
   REDIS_PORT: "6379"
 
-#  MAIL_MAILER: "smtp"
-#  MAIL_HOST: "mail.aspiredev.org"
-#  MAIL_PORT: "1025"
-#  MAIL_USERNAME: ""
-#  MAIL_PASSWORD: ""
-#  MAIL_ENCRYPTION: ""
-#  MAIL_FROM_ADDRESS: "do-not-reply@aspirepress.org"
-#  MAIL_FROM_NAME: "AspireCloud"
+  #  MAIL_MAILER: "smtp"
+  #  MAIL_HOST: "mail.aspiredev.org"
+  #  MAIL_PORT: "1025"
+  #  MAIL_USERNAME: ""
+  #  MAIL_PASSWORD: ""
+  #  MAIL_ENCRYPTION: ""
+  #  MAIL_FROM_ADDRESS: "do-not-reply@aspirepress.org"
+  #  MAIL_FROM_NAME: "AspireCloud"
 
   # used for s3 (and only s3)
   AWS_DEFAULT_REGION: "us-west-1"


### PR DESCRIPTION
# Pull Request

## What changed?

* Switches the deployment tag from `latest` to `0.7` which is the most current tag.  
* Updates configmap to match current .env (fix APP_URL, switch phpredis to redis)

## Why did it change?

When new releases are tagged, deployment.yaml needs to be updated accordingly.  This will allow `kubectl apply` to push a change that the cluster can detect, without having to use `imagePullPolicy: Always`, not to mention the other benefits of tracking the deployed version in version control itself.

This PR is notable because of the bugfixes including the problem with using the `latest` tag.  Otherwise, release PRs should get their own template at some point, the standard one is kind of cumbersome. 

## Did you fix any specific issues?

none

## CERTIFICATION

By opening this pull request, I do agree to abide by the [Code of Conduct](https://github.com/aspirepress/.github/blob/updating-contributor-policy/CODE_OF_CONDUCT.md) and be bound by the terms of the [Contribution Guidelines](https://github.com/aspirepress/.github/blob/updating-contributor-policy/CONTRIBUTING.md) in effect on the date and time of my contribution as proven by the revision information in GitHub.

