### PR TITLE
build: build both amd64 and arm64 arches for container

### DIFF
--- a/meta/bin/build-images
+++ b/meta/bin/build-images
@@ -3,7 +3,7 @@
 . $(dirname $0)/prelude.bash
 
 tag=${TAG:-$(git describe --tags --abbrev=0)}
-platform=${PLATFORM:-linux/arm64} # prod is always arm64
+platform=${PLATFORM:-linux/amd64,linux/arm64}
 
 if [[ -n $GHCR_TOKEN ]]; then
     echo $GHCR_TOKEN | docker login ghcr.io -u userame-is-ignored --password-stdin


### PR DESCRIPTION
# Pull Request

## What changed?

* `meta/bin/build-images` now builds both amd64 and arm64 container images.  Docker Desktop users will need to switch to the containerd store for this to work.

## Why did it change?

* Because aspirecloud.net is on amd64 and aspirecloud.io is arm64

## Did you fix any specific issues?

none

## CERTIFICATION

By opening this pull request, I do agree to abide by the [Code of Conduct](https://github.com/aspirepress/.github/blob/updating-contributor-policy/CODE_OF_CONDUCT.md) and be bound by the terms of the [Contribution Guidelines](https://github.com/aspirepress/.github/blob/updating-contributor-policy/CONTRIBUTING.md) in effect on the date and time of my contribution as proven by the revision information in GitHub.

