### PR TITLE
AC-131: placeholder homepage to replace default laravel page

### DIFF
--- a/resources/views/home.blade.php
+++ b/resources/views/home.blade.php
@@ -6,7 +6,50 @@ use App\Models\User;
 $user ??= auth()->user();
 ?>
 @extends('layouts.plain')
+
 @section('title', 'Welcome - AspireCloud')
+
+@section('content')
+    <main class="homepage">
+        <div class="message">
+            <p>
+                Welcome to the AspireCloud API, a service of <a href="https://www.aspirepress.org">AspirePress</a>.
+            </p>
+            <p>
+                Right now, we're currently in beta testing, but anyone can join.
+                During the beta, you'll need an auth token to access the API: you can get one by registering using
+                the link below, then selecting "API Tokens" from the top-right menu.
+            </p>
+            <hr>
+            <p>Useful links:
+                <a href="https://github.com/aspirepress/aspirecloud" target="_blank">Github</a>
+                | <a href="https://codex.wordpress.org/WordPress.org_API" target="_blank">WordPress API Reference</a>
+            </p>
+        </div>
+
+        <nav>
+            <ul>
+                @if ($user)
+                    <li><a href="{{route('dashboard')}}">Dashboard</a></li>
+                    <li>
+                        <a href="{{ route('logout') }}"
+                           onclick="event.preventDefault(); document.getElementById('logout-form').submit();"
+                        >
+                            Logout
+                        </a>
+                        <form id="logout-form" action="{{ route('logout') }}" method="POST" style="display: none;">
+                            {{ csrf_field() }}
+                        </form>
+                    </li>
+                @else
+                    <li><a href="{{ route('login') }}">Login</a></li>
+                    <li><a href="{{ route('register') }}">Register</a></li>
+                @endif
+            </ul>
+        </nav>
+    </main>
+@endsection
+
 @section('head')
     <style>
         main.homepage {
@@ -56,45 +99,4 @@ $user ??= auth()->user();
             color: deepskyblue;
         }
     </style>
-@endsection
-
-@section('content')
-    <main class="homepage">
-        <div class="message">
-            <p>
-                Welcome to the AspireCloud API, a service of <a href="https://www.aspirepress.org">AspirePress</a>.
-            </p>
-            <p>
-                Right now, we're currently in beta testing, but anyone can join.
-                During the beta, you'll need an auth token to access the API: you can get one by registering using
-                the link below, then selecting "API Tokens" from the top-right menu.
-            </p>
-            <hr>
-            <p>Useful links:
-                <a href="https://github.com/aspirepress/aspirecloud" target="_blank">Github</a>
-                | <a href="https://codex.wordpress.org/WordPress.org_API" target="_blank">WordPress API Reference</a>
-            </p>
-        </div>
-
-        <nav>
-            <ul>
-                @if ($user)
-                    <li><a href="{{route('dashboard')}}">Dashboard</a></li>
-                    <li>
-                        <a href="{{ route('logout') }}"
-                           onclick="event.preventDefault(); document.getElementById('logout-form').submit();"
-                        >
-                            Logout
-                        </a>
-                        <form id="logout-form" action="{{ route('logout') }}" method="POST" style="display: none;">
-                            {{ csrf_field() }}
-                        </form>
-                    </li>
-                @else
-                    <li><a href="{{ route('login') }}">Login</a></li>
-                    <li><a href="{{ route('register') }}">Register</a></li>
-                @endif
-            </ul>
-        </nav>
-    </main>
 @endsection

--- a/resources/views/home.blade.php
+++ b/resources/views/home.blade.php
@@ -1,0 +1,100 @@
+<?php
+
+use App\Models\User;
+
+/** @var User $user */
+$user ??= auth()->user();
+?>
+@extends('layouts.plain')
+@section('title', 'Welcome - AspireCloud')
+@section('head')
+    <style>
+        main.homepage {
+            display: flex;
+            flex-direction: column;
+            align-items: center;
+            justify-content: center;
+            height: 66vh;
+
+            font-family: sans-serif;
+            font-size: 1.5rem;
+        }
+
+        main.homepage .message {
+            width: 66%;
+
+            border: 1px solid lightgrey;
+            box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
+            padding: 1em;
+            border-radius: 8px;
+            background-color: white;
+        }
+
+        main.homepage nav {
+            width: 66%;
+            font-size: 3rem;
+        }
+
+        main.homepage nav ul {
+            list-style: none;
+            display: flex;
+            flex-direction: row;
+            padding: 0;
+            justify-content: space-evenly;
+        }
+
+        main.homepage nav li {
+            margin-top: 1em;
+        }
+
+        main.homepage a {
+            text-decoration: none;
+            color: darkcyan;
+        }
+
+        main.homepage a:hover {
+            color: deepskyblue;
+        }
+    </style>
+@endsection
+
+@section('content')
+    <main class="homepage">
+        <div class="message">
+            <p>
+                Welcome to the AspireCloud API, a service of <a href="https://www.aspirepress.com">AspirePress</a>.
+            </p>
+            <p>
+                Right now, we're currently in beta testing, but anyone can join.
+                During the beta, you'll need an auth token to access the API: you can get one by registering using
+                the link below, then selecting "API Tokens" from the top-right menu.
+            </p>
+            <hr>
+            <p>Useful links:
+                <a href="https://github.com/aspirepress/aspirecloud" target="_blank">Github</a>
+                | <a href="https://codex.wordpress.org/WordPress.org_API" target="_blank">WordPress API Reference</a>
+            </p>
+        </div>
+
+        <nav>
+            <ul>
+                @if ($user)
+                    <li><a href="{{route('dashboard')}}">Dashboard</a></li>
+                    <li>
+                        <a href="{{ route('logout') }}"
+                           onclick="event.preventDefault(); document.getElementById('logout-form').submit();"
+                        >
+                            Logout
+                        </a>
+                        <form id="logout-form" action="{{ route('logout') }}" method="POST" style="display: none;">
+                            {{ csrf_field() }}
+                        </form>
+                    </li>
+                @else
+                    <li><a href="{{ route('login') }}">Login</a></li>
+                    <li><a href="{{ route('register') }}">Register</a></li>
+                @endif
+            </ul>
+        </nav>
+    </main>
+@endsection

--- a/resources/views/home.blade.php
+++ b/resources/views/home.blade.php
@@ -62,7 +62,7 @@ $user ??= auth()->user();
     <main class="homepage">
         <div class="message">
             <p>
-                Welcome to the AspireCloud API, a service of <a href="https://www.aspirepress.com">AspirePress</a>.
+                Welcome to the AspireCloud API, a service of <a href="https://www.aspirepress.org">AspirePress</a>.
             </p>
             <p>
                 Right now, we're currently in beta testing, but anyone can join.

--- a/resources/views/layouts/plain.blade.php
+++ b/resources/views/layouts/plain.blade.php
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html lang="{{ str_replace('_', '-', app()->getLocale()) }}">
+<head>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>@yield('title', config('app.name'))</title>
+    @yield('head')
+</head>
+<body>
+@yield('content')
+</body>
+</html>

--- a/routes/web.php
+++ b/routes/web.php
@@ -4,14 +4,16 @@ use Illuminate\Foundation\Application;
 use Illuminate\Support\Facades\Route;
 use Inertia\Inertia;
 
-Route::get('/', function () {
-    return Inertia::render('Welcome', [
-        'canLogin' => Route::has('login'),
-        'canRegister' => Route::has('register'),
-        'laravelVersion' => Application::VERSION,
-        'phpVersion' => PHP_VERSION,
-    ]);
-});
+// Route::get('/', function () {
+//     return Inertia::render('Welcome', [
+//         'canLogin' => Route::has('login'),
+//         'canRegister' => Route::has('register'),
+//         'laravelVersion' => Application::VERSION,
+//         'phpVersion' => PHP_VERSION,
+//     ]);
+// });
+
+Route::view('/', 'home');
 
 Route::middleware([
     'auth:sanctum',


### PR DESCRIPTION
# Pull Request

## What changed?

Changed from the default Laravel homepage to this:

<img width="785" alt="image" src="https://github.com/user-attachments/assets/8c02cd37-72be-4b01-afee-207f0dd0edc6" />

## Why did it change?

Because using the default page looks pretty lazy.

## Did you fix any specific issues?

Closes: #131 

## CERTIFICATION

By opening this pull request, I do agree to abide by the [Code of Conduct](https://github.com/aspirepress/.github/blob/updating-contributor-policy/CODE_OF_CONDUCT.md) and be bound by the terms of the [Contribution Guidelines](https://github.com/aspirepress/.github/blob/updating-contributor-policy/CONTRIBUTING.md) in effect on the date and time of my contribution as proven by the revision information in GitHub.

