### PR TITLE
use non-root user in docker containers (+bump frankenphp version)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,17 @@
+.cache/
+.github/
+.idea/
+bruno/
+meta/
+node_modules/
+tests/
+tmp/
+vendor/
+
+storage/
+!storage/logs/.gitignore
+
+*.bak
+*.log
+*.swp
+*.tmp

--- a/docker/cli/Dockerfile
+++ b/docker/cli/Dockerfile
@@ -9,6 +9,8 @@ RUN install-php-extensions pdo pdo_pgsql zip intl redis
 
 COPY ./docker/cli/php.ini /usr/local/etc/php/php.ini
 
+RUN useradd --create-home --shell /bin/bash app
+
 WORKDIR /app
 
 ################
@@ -19,6 +21,8 @@ RUN apt update && apt install -y nodejs npm
 # Xdebug exists, but is explicitly disabled for cli.  Use docker-compose.override.yml to enable.
 RUN install-php-extensions xdebug
 RUN sed -i 's/^/#/' /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini
+
+USER app
 
 ################
 # FROM base AS prod

--- a/docker/laravel-worker/Dockerfile
+++ b/docker/laravel-worker/Dockerfile
@@ -9,6 +9,8 @@ RUN install-php-extensions pdo pdo_pgsql zip intl redis
 
 COPY ./docker/cli/php.ini /usr/local/etc/php/php.ini
 
+RUN useradd --create-home --shell /bin/bash app
+
 WORKDIR /app
 
 ################
@@ -18,11 +20,17 @@ FROM base AS dev
 RUN install-php-extensions xdebug
 RUN sed -i 's/^/#/' /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini
 
+USER app
+
 ################
 FROM base AS prod
 
-# TODO: use an external volume
+# no workie, composer can't create /app/vendor ¯\_(ツ)_/¯
+# COPY --chown=app:app . /app
+
 COPY . /app
+RUN chown -R app:app /app
+
+USER app
 
 RUN composer install --no-dev --no-interaction --no-progress --optimize-autoloader --working-dir=/app
-

--- a/docker/webapp/Dockerfile
+++ b/docker/webapp/Dockerfile
@@ -3,26 +3,36 @@ FROM dunglas/frankenphp:1.4.1-php8.4.3-bookworm AS base
 COPY --from=composer:2.8.3 /usr/bin/composer /usr/bin/composer
 ADD --chmod=0755 https://github.com/mlocati/docker-php-extension-installer/releases/download/2.5.2/install-php-extensions /usr/local/bin/
 
-RUN apt update && apt install -y bash git postgresql-client zip
+RUN apt update && apt install -y bash zip
 
 RUN install-php-extensions pdo pdo_pgsql zip intl redis
 
 COPY ./docker/webapp/Caddyfile /etc/caddy/Caddyfile
 COPY ./docker/webapp/php.ini /usr/local/etc/php/php.ini
 
+RUN useradd --create-home --shell /bin/bash app
+
 WORKDIR /app
 
 ################
 FROM base AS dev
 
-RUN apt update && apt install -y nodejs npm
+RUN echo test
+RUN apt update && apt install -y git nodejs npm postgresql-client
 
 RUN install-php-extensions xdebug
+
+USER app
 
 ################
 FROM base AS prod
 
+# no workie, composer can't create /app/vendor ¯\_(ツ)_/¯
+# COPY --chown=app:app . /app
+
 COPY . /app
+RUN chown -R app:app /app
+
+USER app
 
 RUN composer install --no-dev --no-interaction --no-progress --optimize-autoloader --working-dir=/app
-

--- a/docker/webapp/Dockerfile
+++ b/docker/webapp/Dockerfile
@@ -1,4 +1,4 @@
-FROM dunglas/frankenphp:1.2.5-php8.3 AS base
+FROM dunglas/frankenphp:1.4.1-php8.4.3-bookworm AS base
 
 COPY --from=composer:2.8.3 /usr/bin/composer /usr/bin/composer
 ADD --chmod=0755 https://github.com/mlocati/docker-php-extension-installer/releases/download/2.5.2/install-php-extensions /usr/local/bin/


### PR DESCRIPTION
# Pull Request

## What changed?

* Updates all Dockerfiles to use an `app` user instead of root
* Updates to FrankenPHP 1.4.1
* Adds a .dockerignore file (more could be ignored, but I'm not going to sweat it too much)

## Why did it change?

k8s audits scream bloody murder about containers running as root.

## Did you fix any specific issues?

none

## CERTIFICATION

By opening this pull request, I do agree to abide by the [Code of Conduct](https://github.com/aspirepress/.github/blob/updating-contributor-policy/CODE_OF_CONDUCT.md) and be bound by the terms of the [Contribution Guidelines](https://github.com/aspirepress/.github/blob/updating-contributor-policy/CONTRIBUTING.md) in effect on the date and time of my contribution as proven by the revision information in GitHub.

