### PR TITLE
fix: recreate storage dirs in prod container build

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -4,12 +4,10 @@
 bruno/
 meta/
 node_modules/
+storage/
 tests/
 tmp/
 vendor/
-
-storage/
-!storage/logs/.gitignore
 
 *.bak
 *.log

--- a/docker/laravel-worker/Dockerfile
+++ b/docker/laravel-worker/Dockerfile
@@ -34,3 +34,6 @@ RUN chown -R app:app /app
 USER app
 
 RUN composer install --no-dev --no-interaction --no-progress --optimize-autoloader --working-dir=/app
+
+RUN composer install --no-dev --no-interaction --no-progress --optimize-autoloader --working-dir=/app \
+    && mkdir -p storage/logs storage/app/{public,private} storage/framework/{sessions,views} storage/framework/cache/data

--- a/docker/webapp/Dockerfile
+++ b/docker/webapp/Dockerfile
@@ -35,4 +35,5 @@ RUN chown -R app:app /app
 
 USER app
 
-RUN composer install --no-dev --no-interaction --no-progress --optimize-autoloader --working-dir=/app
+RUN composer install --no-dev --no-interaction --no-progress --optimize-autoloader --working-dir=/app \
+    && mkdir -p storage/logs storage/app/{public,private} storage/framework/{sessions,views} storage/framework/cache/data

--- a/docker/webapp/Dockerfile
+++ b/docker/webapp/Dockerfile
@@ -39,4 +39,4 @@ USER app
 WORKDIR /app
 
 RUN composer install --no-dev --no-interaction --no-progress --optimize-autoloader --working-dir=/app \
-    && mkdir -p storage/logs storage/app/{public,private} storage/framework/{sessions,views} storage/framework/cache/data
+    && mkdir -p storage/logs storage/app/public storage/app/private storage/framework/sessions storage/framework/views storage/framework/cache/data

--- a/docker/webapp/Dockerfile
+++ b/docker/webapp/Dockerfile
@@ -10,19 +10,21 @@ RUN install-php-extensions pdo pdo_pgsql zip intl redis
 COPY ./docker/webapp/Caddyfile /etc/caddy/Caddyfile
 COPY ./docker/webapp/php.ini /usr/local/etc/php/php.ini
 
-RUN useradd --create-home --shell /bin/bash app
+# frankenphp sets XDG_CONFIG_HOME=/config and XDG_DATA_HOME=/data, and I won't change these in case they're hardwired
+RUN useradd --create-home --shell /bin/bash app \
+    && chown -R app:app /config /data
 
 WORKDIR /app
 
 ################
 FROM base AS dev
 
-RUN echo test
 RUN apt update && apt install -y git nodejs npm postgresql-client
 
 RUN install-php-extensions xdebug
 
 USER app
+WORKDIR /app
 
 ################
 FROM base AS prod
@@ -34,6 +36,7 @@ COPY . /app
 RUN chown -R app:app /app
 
 USER app
+WORKDIR /app
 
 RUN composer install --no-dev --no-interaction --no-progress --optimize-autoloader --working-dir=/app \
     && mkdir -p storage/logs storage/app/{public,private} storage/framework/{sessions,views} storage/framework/cache/data


### PR DESCRIPTION
# Pull Request

## What changed?

* Docker prod container builds now recreate the directory hierarchy under storage/ because Laravel won't

## Why did it change?

So Laravel won't crash in prod.

## Did you fix any specific issues?

none

## CERTIFICATION

By opening this pull request, I do agree to abide by the [Code of Conduct](https://github.com/aspirepress/.github/blob/updating-contributor-policy/CODE_OF_CONDUCT.md) and be bound by the terms of the [Contribution Guidelines](https://github.com/aspirepress/.github/blob/updating-contributor-policy/CONTRIBUTING.md) in effect on the date and time of my contribution as proven by the revision information in GitHub.

