### PR TITLE
fix: build js assets in prod webapp container

### DIFF
--- a/docker/webapp/Dockerfile
+++ b/docker/webapp/Dockerfile
@@ -24,7 +24,6 @@ RUN apt update && apt install -y git nodejs npm postgresql-client
 RUN install-php-extensions xdebug
 
 USER app
-WORKDIR /app
 
 ################
 FROM base AS prod
@@ -35,8 +34,17 @@ FROM base AS prod
 COPY . /app
 RUN chown -R app:app /app
 
+RUN apt update && apt install -y nodejs npm
+
 USER app
-WORKDIR /app
 
 RUN composer install --no-dev --no-interaction --no-progress --optimize-autoloader --working-dir=/app \
     && mkdir -p storage/logs storage/app/public storage/app/private storage/framework/sessions storage/framework/views storage/framework/cache/data
+
+RUN npm ci && rm -rf public/build && npm run build
+
+USER root
+
+RUN apt purge -y nodejs npm
+
+USER app


### PR DESCRIPTION
# Pull Request

## What changed?

Add missing build step to rebuild assets in the prod container build for webapp

## Why did it change?

Prod was getting whatever dev server build was left over in the build box, which typically won't work.

## Did you fix any specific issues?

none

## CERTIFICATION

By opening this pull request, I do agree to abide by the [Code of Conduct](https://github.com/aspirepress/.github/blob/updating-contributor-policy/CODE_OF_CONDUCT.md) and be bound by the terms of the [Contribution Guidelines](https://github.com/aspirepress/.github/blob/updating-contributor-policy/CONTRIBUTING.md) in effect on the date and time of my contribution as proven by the revision information in GitHub.

