### PR TITLE
add stability warning banner on non-prod systems

### DIFF
--- a/resources/views/home.blade.php
+++ b/resources/views/home.blade.php
@@ -47,6 +47,20 @@ $user ??= auth()->user();
                 @endif
             </ul>
         </nav>
+
+        @if (!app()->isProduction())
+            <div class="warning message">
+                <p>
+                    <strong>Warning:</strong>
+                    This is a development server, and the stability of the platform is not guaranteed. It may be reset
+                    from time to time without warning, requiring you to re-register and generate new API keys.
+                </p>
+                <p>
+                    Email <em>cannot</em> be sent by this server, and thus password resets can only be performed by a site administrator.
+                    Warnings about verifying your account email can be ignored for the time being.
+                </p>
+            </div>
+        @endif
     </main>
 @endsection
 
@@ -86,10 +100,6 @@ $user ??= auth()->user();
             justify-content: space-evenly;
         }
 
-        main.homepage nav li {
-            margin-top: 1em;
-        }
-
         main.homepage a {
             text-decoration: none;
             color: darkcyan;
@@ -97,6 +107,10 @@ $user ??= auth()->user();
 
         main.homepage a:hover {
             color: deepskyblue;
+        }
+
+        main.homepage .warning {
+            background-color: lightyellow;
         }
     </style>
 @endsection


### PR DESCRIPTION
# Pull Request

## What changed?

Homepage now looks like this everywhere but prod:

<img width="1095" alt="image" src="https://github.com/user-attachments/assets/88e533fd-68a8-4a0c-929f-0d3b77aac4d8" />

## Why did it change?

To warn people about no email and getting eaten by big nasty db wipe monster.

## Did you fix any specific issues?

none

## CERTIFICATION

By opening this pull request, I do agree to abide by the [Code of Conduct](https://github.com/aspirepress/.github/blob/updating-contributor-policy/CODE_OF_CONDUCT.md) and be bound by the terms of the [Contribution Guidelines](https://github.com/aspirepress/.github/blob/updating-contributor-policy/CONTRIBUTING.md) in effect on the date and time of my contribution as proven by the revision information in GitHub.

