### PR TITLE
Stream downloads instead of redirecting

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -77,4 +77,6 @@ MAILGUN_SECRET=
 
 # AspirePress Related Configuration
 API_AUTHENTICATION_ENABLED=true
-DOWNLOAD_BASE=https://api.aspiredev.org/download
+DOWNLOAD_BASE=https://api.aspiredev.org/download/
+# DOWNLOAD_BASE=https://fastly.api.aspiredev.org/download/
+DOWNLOAD_CACHE_SECONDS=864000

--- a/.env.example
+++ b/.env.example
@@ -77,3 +77,4 @@ MAILGUN_SECRET=
 
 # AspirePress Related Configuration
 API_AUTHENTICATION_ENABLED=true
+DOWNLOAD_BASE=https://api.aspiredev.org/download

--- a/app/Contracts/Downloads/Downloader.php
+++ b/app/Contracts/Downloads/Downloader.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Contracts\Downloads;
+
+use App\Enums\AssetType;
+use Symfony\Component\HttpFoundation\Response;
+
+interface Downloader
+{
+    public function download(AssetType $type, string $slug, string $file, ?string $revision = null): Response;
+}

--- a/app/Contracts/Downloads/Downloader.php
+++ b/app/Contracts/Downloads/Downloader.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace App\Contracts\Downloads;
 
 use App\Enums\AssetType;
-use Symfony\Component\HttpFoundation\Response;
+use Illuminate\Http\Response;
 
 interface Downloader
 {

--- a/app/Contracts/Downloads/Downloader.php
+++ b/app/Contracts/Downloads/Downloader.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace App\Contracts\Downloads;
 
 use App\Enums\AssetType;
-use Illuminate\Http\Response;
+use Symfony\Component\HttpFoundation\Response;
 
 interface Downloader
 {

--- a/app/Enums/AssetType.php
+++ b/app/Enums/AssetType.php
@@ -12,16 +12,32 @@ enum AssetType: string
     case PLUGIN_GP_ICON = 'plugin-gp-icon'; // geopattern-icon only -- other icons are treated as screenshots
     case THEME_SCREENSHOT = 'theme-screenshot';
 
-    public function isZip(): bool
-    {
-        return in_array($this, [self::CORE, self::PLUGIN, self::THEME]);
-    }
-
-    public function isAsset(): bool
+    public function isImage(): bool
     {
         return in_array(
             $this,
             [self::PLUGIN_SCREENSHOT, self::PLUGIN_BANNER, self::PLUGIN_GP_ICON, self::THEME_SCREENSHOT],
         );
+    }
+
+    public function buildUpstreamUrl(string $slug, string $file, ?string $revision): string
+    {
+        $baseUrl = match ($this) {
+            self::CORE => 'https://wordpress.org/',
+            self::PLUGIN => 'https://downloads.wordpress.org/plugin/',
+            self::THEME => 'https://downloads.wordpress.org/theme/',
+            self::PLUGIN_SCREENSHOT,
+            self::PLUGIN_BANNER => "https://ps.w.org/$slug/assets/",
+            self::PLUGIN_GP_ICON => "https://s.w.org/plugins/geopattern-icon/",
+            self::THEME_SCREENSHOT => "https://ts.w.org/wp-content/themes/$slug/",
+        };
+
+        $url = $baseUrl . $file;
+
+        if ($revision && $this->isImage()) {
+            $url .= "?rev={$revision}";
+        }
+
+        return $url;
     }
 }

--- a/app/Models/WpOrg/Plugin.php
+++ b/app/Models/WpOrg/Plugin.php
@@ -234,7 +234,7 @@ final class Plugin extends BaseModel
 
     private static function rewriteDotOrgUrl(string $url): string
     {
-        $base = config('app.url') . '/download/';
+        $base = config('app.aspirecloud.download.base');
 
         // https://downloads.wordpress.org/plugin/elementor.3.26.5.zip
         // => /download/plugin/elementor.3.26.5.zip

--- a/app/Models/WpOrg/Theme.php
+++ b/app/Models/WpOrg/Theme.php
@@ -182,7 +182,7 @@ final class Theme extends BaseModel
             return $metadata;
         }
 
-        $base = config('app.url') . '/download/';
+        $base = config('app.aspirecloud.download.base');
         $rewrite = fn(string $url) => \Safe\preg_replace('#https?://.*?/#i', $base, $url);
 
         $download_link = $rewrite($metadata['download_link'] ?? '');

--- a/app/Services/Downloads/DownloadService.php
+++ b/app/Services/Downloads/DownloadService.php
@@ -36,8 +36,10 @@ class DownloadService implements Downloader
             event(new AssetCacheHit($asset));
             Log::debug("Serving existing asset", ["asset" => $asset]);
             $stream = Storage::disk('s3')->getDriver()->readStream($asset->local_path);
-            return response()->stream(fn() => fpassthru($stream),
-                headers: ['Content-Type' => 'application/octet-stream']);
+            return response()->stream(
+                fn() => fpassthru($stream),
+                headers: ['Content-Type' => 'application/octet-stream'],
+            );
         }
 
         $upstreamUrl = $type->buildUpstreamUrl($slug, $file, $revision);

--- a/app/Services/Downloads/DownloadService.php
+++ b/app/Services/Downloads/DownloadService.php
@@ -7,10 +7,10 @@ use App\Enums\AssetType;
 use App\Events\AssetCacheHit;
 use App\Events\AssetCacheMissed;
 use App\Models\WpOrg\Asset;
+use Illuminate\Http\Response;
 use Illuminate\Support\Facades\Http;
 use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\Storage;
-use Symfony\Component\HttpFoundation\Response;
 
 class DownloadService implements Downloader
 {

--- a/app/Services/Downloads/DownloadService.php
+++ b/app/Services/Downloads/DownloadService.php
@@ -7,10 +7,10 @@ use App\Enums\AssetType;
 use App\Events\AssetCacheHit;
 use App\Events\AssetCacheMissed;
 use App\Models\WpOrg\Asset;
-use Illuminate\Http\Response;
 use Illuminate\Support\Facades\Http;
 use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\Storage;
+use Symfony\Component\HttpFoundation\Response;
 
 class DownloadService implements Downloader
 {
@@ -50,5 +50,4 @@ class DownloadService implements Downloader
         $response = Http::withHeaders(['User-Agent' => 'AspireCloud'])->get($upstreamUrl);
         return new Response($response->body(), $response->status(), $response->headers());
     }
-
 }

--- a/app/Services/Downloads/RedirectingDownloadService.php
+++ b/app/Services/Downloads/RedirectingDownloadService.php
@@ -7,9 +7,9 @@ use App\Enums\AssetType;
 use App\Events\AssetCacheHit;
 use App\Events\AssetCacheMissed;
 use App\Models\WpOrg\Asset;
+use Illuminate\Http\Response;
 use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\Storage;
-use Symfony\Component\HttpFoundation\Response;
 
 class RedirectingDownloadService implements Downloader
 {

--- a/app/Services/Downloads/RedirectingDownloadService.php
+++ b/app/Services/Downloads/RedirectingDownloadService.php
@@ -6,13 +6,18 @@ use App\Enums\AssetType;
 use App\Events\AssetCacheHit;
 use App\Events\AssetCacheMissed;
 use App\Models\WpOrg\Asset;
-use Illuminate\Support\Facades\Http;
 use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\Storage;
 use Symfony\Component\HttpFoundation\Response;
 
-class DownloadService
+class RedirectingDownloadService
 {
+    public const int TEMPORARY_URL_EXPIRE_MINS = 5;
+
+    /**
+     * Get the file download response. If the asset exists locally, return a redirect url to it.
+     * Otherwise, redirect to WordPress.org and queue a job to download it for future requests.
+     */
     public function download(AssetType $type, string $slug, string $file, ?string $revision = null): Response
     {
         Log::debug("DOWNLOAD", compact("type", "slug", "file", "revision"));
@@ -34,18 +39,17 @@ class DownloadService
             // TODO: handle case where asset exists but local path does not (DownloadAssetJob always creates a new Asset)
             event(new AssetCacheHit($asset));
             Log::debug("Serving existing asset", ["asset" => $asset]);
-            $stream = Storage::disk('s3')->getDriver()->readStream($asset->local_path);
-            return response()->stream(fn() => fpassthru($stream),
-                headers: ['Content-Type' => 'application/octet-stream']);
+            return $this->response(
+                Storage::temporaryUrl($asset->local_path, now()->addMinutes(self::TEMPORARY_URL_EXPIRE_MINS)),
+            );
         }
 
         $upstreamUrl = self::buildUpstreamUrl($type, $slug, $file, $revision);
 
-        event(new AssetCacheMissed(type: $type, slug: $slug, file: $file, upstreamUrl: $upstreamUrl, revision: $revision));
-
-        // TODO: use a real client.  Plugins are small enough we can get away with this for now.
-        $response = Http::withHeaders(['User-Agent' => 'AspireCloud'])->get($upstreamUrl);
-        return new Response($response->body(), $response->status(), $response->headers());
+        event(
+            new AssetCacheMissed(type: $type, slug: $slug, file: $file, upstreamUrl: $upstreamUrl, revision: $revision),
+        );
+        return $this->response($upstreamUrl);
     }
 
     public static function buildUpstreamUrl(AssetType $type, string $slug, string $file, ?string $revision): string
@@ -67,5 +71,10 @@ class DownloadService
         }
 
         return $url;
+    }
+
+    private function response(string $url): Response
+    {
+        return redirect()->away($url);
     }
 }

--- a/app/Services/Downloads/RedirectingDownloadService.php
+++ b/app/Services/Downloads/RedirectingDownloadService.php
@@ -7,7 +7,7 @@ use App\Enums\AssetType;
 use App\Events\AssetCacheHit;
 use App\Events\AssetCacheMissed;
 use App\Models\WpOrg\Asset;
-use Illuminate\Http\Response;
+use Illuminate\Http\RedirectResponse;
 use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\Storage;
 
@@ -19,7 +19,7 @@ class RedirectingDownloadService implements Downloader
      * Get the file download response. If the asset exists locally, return a redirect url to it.
      * Otherwise, redirect to WordPress.org and queue a job to download it for future requests.
      */
-    public function download(AssetType $type, string $slug, string $file, ?string $revision = null): Response
+    public function download(AssetType $type, string $slug, string $file, ?string $revision = null): RedirectResponse
     {
         Log::debug("DOWNLOAD", compact("type", "slug", "file", "revision"));
 
@@ -53,7 +53,7 @@ class RedirectingDownloadService implements Downloader
         return $this->response($upstreamUrl);
     }
 
-    private function response(string $url): Response
+    private function response(string $url): RedirectResponse
     {
         return redirect()->away($url);
     }

--- a/config/app.php
+++ b/config/app.php
@@ -29,5 +29,7 @@ return [
 
     'aspirecloud' => [
         'api_authentication_enable' => env('API_AUTHENTICATION_ENABLED', false),
+        'download_base' => env('DOWNLOAD_BASE', env('APP_URL') . '/download'),
     ],
+
 ];

--- a/config/app.php
+++ b/config/app.php
@@ -30,8 +30,8 @@ return [
     'aspirecloud' => [
         'api_authentication_enable' => env('API_AUTHENTICATION_ENABLED', false),
         'download' => [
-            'base' => env('DOWNLOAD_BASE', env('APP_URL') . '/download'),
-            'cache_seconds' => env('DOWNLOAD_CACHE_SECONDS', 60 * 60 * 24 * 7),
+            'base' => env('DOWNLOAD_BASE', env('APP_URL') . '/download/'), # must have a trailing slash!
+            'cache_seconds' => env('DOWNLOAD_CACHE_SECONDS', 60 * 60 * 24 * 10),
         ],
     ],
 ];

--- a/config/app.php
+++ b/config/app.php
@@ -29,7 +29,9 @@ return [
 
     'aspirecloud' => [
         'api_authentication_enable' => env('API_AUTHENTICATION_ENABLED', false),
-        'download_base' => env('DOWNLOAD_BASE', env('APP_URL') . '/download'),
+        'download' => [
+            'base' => env('DOWNLOAD_BASE', env('APP_URL') . '/download'),
+            'cache_seconds' => env('DOWNLOAD_CACHE_SECONDS', 60 * 60 * 24 * 7),
+        ],
     ],
-
 ];

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -23,11 +23,13 @@
         <env name="BCRYPT_ROUNDS" value="4"/>
         <env name="CACHE_STORE" value="array"/>
         <env name="DB_CONNECTION" value="test"/>
-        <env name="DB_HOST" value="db.aspiredev.org"/>
-        <env name="DB_PORT" value="5432"/>
         <env name="DB_DATABASE" value="aspirecloud_testing"/>
-        <env name="DB_USERNAME" value="postgres"/>
+        <env name="DB_HOST" value="db.aspiredev.org"/>
         <env name="DB_PASSWORD" value="password"/>
+        <env name="DB_PORT" value="5432"/>
+        <env name="DB_USERNAME" value="postgres"/>
+        <env name="LOG_CHANNEL" value="null"/>
+        <env name="LOG_LEVEL" value="debug"/>
         <env name="MAIL_MAILER" value="array"/>
         <env name="PULSE_ENABLED" value="false"/>
         <env name="QUEUE_CONNECTION" value="sync"/>

--- a/routes/api.php
+++ b/routes/api.php
@@ -68,4 +68,3 @@ $routeDefinition
 
 require __DIR__ . '/inc/admin-api.php';
 require __DIR__ . '/inc/download.php';
-

--- a/routes/api.php
+++ b/routes/api.php
@@ -67,3 +67,5 @@ $routeDefinition
 // Route::any('{path}', CatchAllController::class)->where('path', '.*');
 
 require __DIR__ . '/inc/admin-api.php';
+require __DIR__ . '/inc/download.php';
+

--- a/routes/inc/download.php
+++ b/routes/inc/download.php
@@ -10,7 +10,7 @@ use Illuminate\Routing\Router;
 use Illuminate\Support\Facades\Route;
 
 $auth_middleware = config('app.aspirecloud.api_authentication_enable') ? ['auth:sanctum'] : [];
-$cache_seconds = config('app.aspirecloud.cache_seconds');
+$cache_seconds = config('app.aspirecloud.download.cache_seconds');
 $middleware = [
     "cache.headers:public;max_age=$cache_seconds", // we're streaming responses, so no etags
     ...$auth_middleware,

--- a/routes/inc/download.php
+++ b/routes/inc/download.php
@@ -10,8 +10,9 @@ use Illuminate\Routing\Router;
 use Illuminate\Support\Facades\Route;
 
 $auth_middleware = config('app.aspirecloud.api_authentication_enable') ? ['auth:sanctum'] : [];
+$cache_seconds = config('app.aspirecloud.cache_seconds');
 $middleware = [
-    'cache.headers:public;max_age=60', // cache 302 redirects for 1 minute while we fetch it
+    "cache.headers:public;max_age=$cache_seconds", // we're streaming responses, so no etags
     ...$auth_middleware,
 ];
 

--- a/routes/web.php
+++ b/routes/web.php
@@ -27,4 +27,3 @@ Route::middleware([
 });
 
 require __DIR__ . '/inc/admin-web.php';
-require __DIR__ . '/inc/download.php';

--- a/tests/Feature/Download/DownloadRedirectsTest.php
+++ b/tests/Feature/Download/DownloadRedirectsTest.php
@@ -23,7 +23,9 @@ describe('Download Routes', function () {
     it('handles WordPress core download requests', function () {
         $response = $this->get('/download/wordpress-6.4.2.zip');
 
-        expect($response->status())->toBe(200); // TODO: write more assertions
+        expect($response->status())->toBe(302);
+        /** @noinspection PhpUndefinedMethodInspection */
+        expect($response->getTargetUrl())->toBe('https://wordpress.org/wordpress-6.4.2.zip');
 
         $job = getDownloadJob();
         expect($job->type)
@@ -37,7 +39,9 @@ describe('Download Routes', function () {
     it('handles plugin download requests', function () {
         $response = $this->get('/download/plugin/test-plugin.1.0.0.zip');
 
-        expect($response->status())->toBe(200); // TODO: write more assertions
+        expect($response->status())->toBe(302);
+        /** @noinspection PhpUndefinedMethodInspection */
+        expect($response->getTargetUrl())->toBe('https://downloads.wordpress.org/plugin/test-plugin.1.0.0.zip');
 
         $job = getDownloadJob();
         expect($job->type)
@@ -51,7 +55,9 @@ describe('Download Routes', function () {
     it('handles theme download requests', function () {
         $response = $this->get('/download/theme/test-theme.1.0.0.zip');
 
-        expect($response->status())->toBe(200); // TODO: write more assertions
+        expect($response->status())->toBe(302);
+        /** @noinspection PhpUndefinedMethodInspection */
+        expect($response->getTargetUrl())->toBe('https://downloads.wordpress.org/theme/test-theme.1.0.0.zip');
 
         $job = getDownloadJob();
         expect($job->type)
@@ -64,7 +70,9 @@ describe('Download Routes', function () {
 
     it('handles plugin asset download requests', function () {
         $response = $this->get('/download/assets/plugin/test-plugin/head/screenshot-1.png');
-        expect($response->status())->toBe(200); // TODO: write more assertions
+        expect($response->status())->toBe(302);
+        /** @noinspection PhpUndefinedMethodInspection */
+        expect($response->getTargetUrl())->toBe('https://ps.w.org/test-plugin/assets/screenshot-1.png');
 
         $job = getDownloadJob();
         expect($job->type)
@@ -78,7 +86,9 @@ describe('Download Routes', function () {
     it('handles asset download requests with revision', function () {
         $response = $this->get('/download/assets/plugin/test-plugin/3164133/banner-1544x500.png');
 
-        expect($response->status())->toBe(200); // TODO: write more assertions
+        expect($response->status())->toBe(302);
+        /** @noinspection PhpUndefinedMethodInspection */
+        expect($response->getTargetUrl())->toBe('https://ps.w.org/test-plugin/assets/banner-1544x500.png?rev=3164133');
 
         $job = getDownloadJob();
         expect($job->type)
@@ -88,4 +98,4 @@ describe('Download Routes', function () {
             ->and($job->upstreamUrl)->toBe('https://ps.w.org/test-plugin/assets/banner-1544x500.png?rev=3164133')
             ->and($job->revision)->toBe('3164133');
     });
-});
+})->todo("turn these into tests of AssetType::buildUpstreamUrl");

--- a/tests/Feature/Download/DownloadRedirectsTest.php
+++ b/tests/Feature/Download/DownloadRedirectsTest.php
@@ -12,22 +12,23 @@ beforeEach(function () {
     Http::fake();
 });
 
-function getDownloadJob(): DownloadAssetJob
-{
-    $jobs = Queue::pushed(DownloadAssetJob::class);
-    expect($jobs)->toHaveCount(1);
-    return $jobs->first();
-}
+
 
 describe('Download Routes', function () {
-    it('handles WordPress core download requests', function () {
+    $getJob = function (): DownloadAssetJob {
+        $jobs = Queue::pushed(DownloadAssetJob::class);
+        expect($jobs)->toHaveCount(1);
+        return $jobs->first();
+    };
+
+    it('handles WordPress core download requests', function () use ($getJob) {
         $response = $this->get('/download/wordpress-6.4.2.zip');
 
         expect($response->status())->toBe(302);
         /** @noinspection PhpUndefinedMethodInspection */
         expect($response->getTargetUrl())->toBe('https://wordpress.org/wordpress-6.4.2.zip');
 
-        $job = getDownloadJob();
+        $job = $getJob();
         expect($job->type)
             ->toBe(AssetType::CORE)
             ->and($job->file)->toBe('wordpress-6.4.2.zip')
@@ -36,14 +37,14 @@ describe('Download Routes', function () {
             ->and($job->revision)->toBeNull();
     });
 
-    it('handles plugin download requests', function () {
+    it('handles plugin download requests', function () use ($getJob) {
         $response = $this->get('/download/plugin/test-plugin.1.0.0.zip');
 
         expect($response->status())->toBe(302);
         /** @noinspection PhpUndefinedMethodInspection */
         expect($response->getTargetUrl())->toBe('https://downloads.wordpress.org/plugin/test-plugin.1.0.0.zip');
 
-        $job = getDownloadJob();
+        $job = $getJob();
         expect($job->type)
             ->toBe(AssetType::PLUGIN)
             ->and($job->file)->toBe('test-plugin.1.0.0.zip')
@@ -52,14 +53,14 @@ describe('Download Routes', function () {
             ->and($job->revision)->toBeNull();
     });
 
-    it('handles theme download requests', function () {
+    it('handles theme download requests', function () use ($getJob) {
         $response = $this->get('/download/theme/test-theme.1.0.0.zip');
 
         expect($response->status())->toBe(302);
         /** @noinspection PhpUndefinedMethodInspection */
         expect($response->getTargetUrl())->toBe('https://downloads.wordpress.org/theme/test-theme.1.0.0.zip');
 
-        $job = getDownloadJob();
+        $job = $getJob();
         expect($job->type)
             ->toBe(AssetType::THEME)
             ->and($job->file)->toBe('test-theme.1.0.0.zip')
@@ -68,13 +69,13 @@ describe('Download Routes', function () {
             ->and($job->revision)->toBeNull();
     });
 
-    it('handles plugin asset download requests', function () {
+    it('handles plugin asset download requests', function () use ($getJob) {
         $response = $this->get('/download/assets/plugin/test-plugin/head/screenshot-1.png');
         expect($response->status())->toBe(302);
         /** @noinspection PhpUndefinedMethodInspection */
         expect($response->getTargetUrl())->toBe('https://ps.w.org/test-plugin/assets/screenshot-1.png');
 
-        $job = getDownloadJob();
+        $job = $getJob();
         expect($job->type)
             ->toBe(AssetType::PLUGIN_SCREENSHOT)
             ->and($job->file)->toBe('screenshot-1.png')
@@ -83,14 +84,14 @@ describe('Download Routes', function () {
             ->and($job->revision)->toBeNull();
     });
 
-    it('handles asset download requests with revision', function () {
+    it('handles asset download requests with revision', function () use ($getJob) {
         $response = $this->get('/download/assets/plugin/test-plugin/3164133/banner-1544x500.png');
 
         expect($response->status())->toBe(302);
         /** @noinspection PhpUndefinedMethodInspection */
         expect($response->getTargetUrl())->toBe('https://ps.w.org/test-plugin/assets/banner-1544x500.png?rev=3164133');
 
-        $job = getDownloadJob();
+        $job = $getJob();
         expect($job->type)
             ->toBe(AssetType::PLUGIN_BANNER)
             ->and($job->file)->toBe('banner-1544x500.png')

--- a/tests/Feature/Download/DownloadRoutesTest.php
+++ b/tests/Feature/Download/DownloadRoutesTest.php
@@ -12,20 +12,19 @@ beforeEach(function () {
     Http::fake();
 });
 
-function getDownloadJob(): DownloadAssetJob
-{
-    $jobs = Queue::pushed(DownloadAssetJob::class);
-    expect($jobs)->toHaveCount(1);
-    return $jobs->first();
-}
-
 describe('Download Routes', function () {
-    it('handles WordPress core download requests', function () {
+    $getJob = function (): DownloadAssetJob {
+        $jobs = Queue::pushed(DownloadAssetJob::class);
+        expect($jobs)->toHaveCount(1);
+        return $jobs->first();
+    };
+
+    it('handles WordPress core download requests', function () use ($getJob) {
         $response = $this->get('/download/wordpress-6.4.2.zip');
 
         expect($response->status())->toBe(200); // TODO: write more assertions
 
-        $job = getDownloadJob();
+        $job = $getJob();
         expect($job->type)
             ->toBe(AssetType::CORE)
             ->and($job->file)->toBe('wordpress-6.4.2.zip')
@@ -34,12 +33,12 @@ describe('Download Routes', function () {
             ->and($job->revision)->toBeNull();
     });
 
-    it('handles plugin download requests', function () {
+    it('handles plugin download requests', function () use ($getJob) {
         $response = $this->get('/download/plugin/test-plugin.1.0.0.zip');
 
         expect($response->status())->toBe(200); // TODO: write more assertions
 
-        $job = getDownloadJob();
+        $job = $getJob();
         expect($job->type)
             ->toBe(AssetType::PLUGIN)
             ->and($job->file)->toBe('test-plugin.1.0.0.zip')
@@ -48,12 +47,12 @@ describe('Download Routes', function () {
             ->and($job->revision)->toBeNull();
     });
 
-    it('handles theme download requests', function () {
+    it('handles theme download requests', function () use ($getJob) {
         $response = $this->get('/download/theme/test-theme.1.0.0.zip');
 
         expect($response->status())->toBe(200); // TODO: write more assertions
 
-        $job = getDownloadJob();
+        $job = $getJob();
         expect($job->type)
             ->toBe(AssetType::THEME)
             ->and($job->file)->toBe('test-theme.1.0.0.zip')
@@ -62,11 +61,11 @@ describe('Download Routes', function () {
             ->and($job->revision)->toBeNull();
     });
 
-    it('handles plugin asset download requests', function () {
+    it('handles plugin asset download requests', function () use ($getJob) {
         $response = $this->get('/download/assets/plugin/test-plugin/head/screenshot-1.png');
         expect($response->status())->toBe(200); // TODO: write more assertions
 
-        $job = getDownloadJob();
+        $job = $getJob();
         expect($job->type)
             ->toBe(AssetType::PLUGIN_SCREENSHOT)
             ->and($job->file)->toBe('screenshot-1.png')
@@ -75,12 +74,12 @@ describe('Download Routes', function () {
             ->and($job->revision)->toBeNull();
     });
 
-    it('handles asset download requests with revision', function () {
+    it('handles asset download requests with revision', function () use ($getJob) {
         $response = $this->get('/download/assets/plugin/test-plugin/3164133/banner-1544x500.png');
 
         expect($response->status())->toBe(200); // TODO: write more assertions
 
-        $job = getDownloadJob();
+        $job = $getJob();
         expect($job->type)
             ->toBe(AssetType::PLUGIN_BANNER)
             ->and($job->file)->toBe('banner-1544x500.png')

--- a/tests/Feature/Download/DownloadRoutesTest.php
+++ b/tests/Feature/Download/DownloadRoutesTest.php
@@ -22,7 +22,7 @@ describe('Download Routes', function () {
     it('handles WordPress core download requests', function () use ($getJob) {
         $response = $this->get('/download/wordpress-6.4.2.zip');
 
-        expect($response->status())->toBe(200); // TODO: write more assertions
+        expect($response->getStatusCode())->toBe(200); // TODO: write more assertions
 
         $job = $getJob();
         expect($job->type)
@@ -36,7 +36,7 @@ describe('Download Routes', function () {
     it('handles plugin download requests', function () use ($getJob) {
         $response = $this->get('/download/plugin/test-plugin.1.0.0.zip');
 
-        expect($response->status())->toBe(200); // TODO: write more assertions
+        expect($response->getStatusCode())->toBe(200); // TODO: write more assertions
 
         $job = $getJob();
         expect($job->type)
@@ -50,7 +50,7 @@ describe('Download Routes', function () {
     it('handles theme download requests', function () use ($getJob) {
         $response = $this->get('/download/theme/test-theme.1.0.0.zip');
 
-        expect($response->status())->toBe(200); // TODO: write more assertions
+        expect($response->getStatusCode())->toBe(200); // TODO: write more assertions
 
         $job = $getJob();
         expect($job->type)
@@ -63,7 +63,7 @@ describe('Download Routes', function () {
 
     it('handles plugin asset download requests', function () use ($getJob) {
         $response = $this->get('/download/assets/plugin/test-plugin/head/screenshot-1.png');
-        expect($response->status())->toBe(200); // TODO: write more assertions
+        expect($response->getStatusCode())->toBe(200); // TODO: write more assertions
 
         $job = $getJob();
         expect($job->type)
@@ -77,7 +77,7 @@ describe('Download Routes', function () {
     it('handles asset download requests with revision', function () use ($getJob) {
         $response = $this->get('/download/assets/plugin/test-plugin/3164133/banner-1544x500.png');
 
-        expect($response->status())->toBe(200); // TODO: write more assertions
+        expect($response->getStatusCode())->toBe(200); // TODO: write more assertions
 
         $job = $getJob();
         expect($job->type)


### PR DESCRIPTION
# Pull Request

## What changed?

* DownloadService now sends file contents directly rather than sending redirects.
* The old redirect behavior now lives in RedirectingDownloadService.  It should probably merge back at some point, but this will do.
* All downloads now have a cache expiration of 10 days (configurable in environment)
* The base url for downloads is now configurable with the `DOWNLOAD_BASE` environment variable, allowing it to be retargeted at a CDN without redeploying.  This setting takes effect at the time metadata is imported.

### Known Issues

Currently when we proxy the download to .org we buffer the entire response before sending, rather than streaming it like we do with the S3 bucket.  It's not ideal, but (most) plugins aren't that big.  If it does barf on the size of an upstream asset, the next request will get it streamed from S3 anyway.

## Why did it change?

In order for Fastly to cache our content, we have to originate it ourselves instead of redirecting.  The cache expiration of 10 days should give Fastly's tires a good kicking, and we can bump it up later.

## Did you fix any specific issues?

none

## CERTIFICATION

By opening this pull request, I do agree to abide by the [Code of Conduct](https://github.com/aspirepress/.github/blob/updating-contributor-policy/CODE_OF_CONDUCT.md) and be bound by the terms of the [Contribution Guidelines](https://github.com/aspirepress/.github/blob/updating-contributor-policy/CONTRIBUTING.md) in effect on the date and time of my contribution as proven by the revision information in GitHub.

