### PR TITLE
config: add trusted_proxies to Caddyfile

### DIFF
--- a/docker/webapp/Caddyfile
+++ b/docker/webapp/Caddyfile
@@ -1,9 +1,13 @@
 {
-  frankenphp
+    frankenphp
+    servers {
+        trusted_proxies static private_ranges
+        trusted_proxies_strict
+    }
 }
 
 http:// {
-  root * /app/public
-  php_server
-  log
+    root * /app/public
+    php_server
+    log
 }


### PR DESCRIPTION
# Pull Request

## What changed?

Adds this stanza to the Caddyfile:
```caddyfile
    servers {
        trusted_proxies static private_ranges
        trusted_proxies_strict
    }
```

As usual with Caddy, the writeup is more typing than the change itself 😛 

## Why did it change?

This enables the `client_ip` field in caddy logfiles, which is the actual originating IP, not the ingress/balancer/proxy.  Docker desktop users might not see any difference, but it should do the trick on staging/prod.

## Did you fix any specific issues?

none

## CERTIFICATION

By opening this pull request, I do agree to abide by the [Code of Conduct](https://github.com/aspirepress/.github/blob/updating-contributor-policy/CODE_OF_CONDUCT.md) and be bound by the terms of the [Contribution Guidelines](https://github.com/aspirepress/.github/blob/updating-contributor-policy/CONTRIBUTING.md) in effect on the date and time of my contribution as proven by the revision information in GitHub.

