### PR TITLE
drop api keys on downloads

### DIFF
--- a/docker/laravel-worker/Dockerfile
+++ b/docker/laravel-worker/Dockerfile
@@ -1,7 +1,7 @@
 FROM php:8.3-cli AS base
 
-COPY --from=composer:2.8.3 /usr/bin/composer /usr/bin/composer
-ADD --chmod=0755 https://github.com/mlocati/docker-php-extension-installer/releases/download/2.5.2/install-php-extensions /usr/local/bin/
+COPY --from=composer:2.8.5 /usr/bin/composer /usr/bin/composer
+ADD --chmod=0755 https://github.com/mlocati/docker-php-extension-installer/releases/download/2.7.14/install-php-extensions /usr/local/bin/
 
 RUN apt update && apt install -y bash git postgresql-client zip
 
@@ -32,8 +32,6 @@ COPY . /app
 RUN chown -R app:app /app
 
 USER app
-
-RUN composer install --no-dev --no-interaction --no-progress --optimize-autoloader --working-dir=/app
 
 RUN composer install --no-dev --no-interaction --no-progress --optimize-autoloader --working-dir=/app \
     && mkdir -p storage/logs storage/app/public storage/app/private storage/framework/sessions storage/framework/views storage/framework/cache/data

--- a/docker/webapp/Dockerfile
+++ b/docker/webapp/Dockerfile
@@ -1,7 +1,7 @@
 FROM dunglas/frankenphp:1.4.1-php8.4.3-bookworm AS base
 
-COPY --from=composer:2.8.3 /usr/bin/composer /usr/bin/composer
-ADD --chmod=0755 https://github.com/mlocati/docker-php-extension-installer/releases/download/2.5.2/install-php-extensions /usr/local/bin/
+COPY --from=composer:2.8.5 /usr/bin/composer /usr/bin/composer
+ADD --chmod=0755 https://github.com/mlocati/docker-php-extension-installer/releases/download/2.7.14/install-php-extensions /usr/local/bin/
 
 RUN apt update && apt install -y bash zip
 
@@ -11,15 +11,18 @@ COPY ./docker/webapp/Caddyfile /etc/caddy/Caddyfile
 COPY ./docker/webapp/php.ini /usr/local/etc/php/php.ini
 
 # frankenphp sets XDG_CONFIG_HOME=/config and XDG_DATA_HOME=/data, and I won't change these in case they're hardwired
+
 RUN useradd --create-home --shell /bin/bash app \
-    && chown -R app:app /config /data
+    && chown -R app:app /config /data \
+    && apt update \
+    && apt install -y nodejs npm postgresql-client
 
 WORKDIR /app
 
 ################
 FROM base AS dev
 
-RUN apt update && apt install -y git nodejs npm postgresql-client
+RUN apt update && apt install -y git
 
 RUN install-php-extensions xdebug
 
@@ -33,8 +36,6 @@ FROM base AS prod
 
 COPY . /app
 RUN chown -R app:app /app
-
-RUN apt update && apt install -y nodejs npm
 
 USER app
 

--- a/routes/inc/download.php
+++ b/routes/inc/download.php
@@ -9,11 +9,12 @@ use App\Http\Controllers\API\WpOrg\Downloads\DownloadThemeScreenshotController;
 use Illuminate\Routing\Router;
 use Illuminate\Support\Facades\Route;
 
-$auth_middleware = config('app.aspirecloud.api_authentication_enable') ? ['auth:sanctum'] : [];
+// downloads can never require api keys, they're fetched by ordinary browser UI and by WP in places we don't hook.
+// $auth_middleware = config('app.aspirecloud.api_authentication_enable') ? ['auth:sanctum'] : [];
 $cache_seconds = config('app.aspirecloud.download.cache_seconds');
 $middleware = [
     "cache.headers:public;max_age=$cache_seconds", // we're streaming responses, so no etags
-    ...$auth_middleware,
+    // ...$auth_middleware,
 ];
 
 Route::prefix('/')


### PR DESCRIPTION
# Pull Request

## What changed?

Removes the API key requirement on downloads, because they're also fetched by ordinary web UI as well as WP in places we  don't hook.

This also slips in a refactor of the Dockerfiles, since I didn't feel like making a whole new branch for this.

## Why did it change?

Dropping the API key requirement for downloads was in the plans anyway, it just had to happen sooner rather than later.

## Did you fix any specific issues?

none, but h/t to @namithj and Jarko on slack for the heads up 🎩 

## CERTIFICATION

By opening this pull request, I do agree to abide by the [Code of Conduct](https://github.com/aspirepress/.github/blob/updating-contributor-policy/CODE_OF_CONDUCT.md) and be bound by the terms of the [Contribution Guidelines](https://github.com/aspirepress/.github/blob/updating-contributor-policy/CONTRIBUTING.md) in effect on the date and time of my contribution as proven by the revision information in GitHub.

