### PR TITLE
fix db error in assets table, docker fixes for production

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -9,6 +9,10 @@ tests/
 tmp/
 vendor/
 
+# prod uses real environment variables only
+.env
+.env.*
+
 *.bak
 *.log
 *.swp

--- a/app/Models/WpOrg/Asset.php
+++ b/app/Models/WpOrg/Asset.php
@@ -49,4 +49,9 @@ class Asset extends Model
         'created_at' => 'datetime',
         'updated_at' => 'datetime',
     ];
+
+    /** @var array<string, mixed> */
+    protected $attributes = [
+        'repository' => 'wp_org', // this is the db default as well since 0.9.3, but it's handy to have it here too
+    ];
 }

--- a/config/telescope.php
+++ b/config/telescope.php
@@ -4,56 +4,9 @@ use Laravel\Telescope\Http\Middleware\Authorize;
 use Laravel\Telescope\Watchers;
 
 return [
-    /*
-    |--------------------------------------------------------------------------
-    | Telescope Master Switch
-    |--------------------------------------------------------------------------
-    |
-    | This option may be used to disable all Telescope watchers regardless
-    | of their individual configuration, which simply provides a single
-    | and convenient way to enable or disable Telescope data storage.
-    |
-    */
-
-    'enabled' => env('TELESCOPE_ENABLED', true),
-
-    /*
-    |--------------------------------------------------------------------------
-    | Telescope Domain
-    |--------------------------------------------------------------------------
-    |
-    | This is the subdomain where Telescope will be accessible from. If the
-    | setting is null, Telescope will reside under the same domain as the
-    | application. Otherwise, this value will be used as the subdomain.
-    |
-    */
-
+    'enabled' => env('TELESCOPE_ENABLED', false),
     'domain' => env('TELESCOPE_DOMAIN'),
-
-    /*
-    |--------------------------------------------------------------------------
-    | Telescope Path
-    |--------------------------------------------------------------------------
-    |
-    | This is the URI path where Telescope will be accessible from. Feel free
-    | to change this path to anything you like. Note that the URI will not
-    | affect the paths of its internal API that aren't exposed to users.
-    |
-    */
-
     'path' => env('TELESCOPE_PATH', 'telescope'),
-
-    /*
-    |--------------------------------------------------------------------------
-    | Telescope Storage Driver
-    |--------------------------------------------------------------------------
-    |
-    | This configuration options determines the storage driver that will
-    | be used to store Telescope's data. In addition, you may set any
-    | custom options as needed by the particular driver you choose.
-    |
-    */
-
     'driver' => env('TELESCOPE_DRIVER', 'database'),
 
     'storage' => [
@@ -63,48 +16,15 @@ return [
         ],
     ],
 
-    /*
-    |--------------------------------------------------------------------------
-    | Telescope Queue
-    |--------------------------------------------------------------------------
-    |
-    | This configuration options determines the queue connection and queue
-    | which will be used to process ProcessPendingUpdate jobs. This can
-    | be changed if you would prefer to use a non-default connection.
-    |
-    */
-
     'queue' => [
         'connection' => env('TELESCOPE_QUEUE_CONNECTION', null),
         'queue' => env('TELESCOPE_QUEUE', null),
     ],
 
-    /*
-    |--------------------------------------------------------------------------
-    | Telescope Route Middleware
-    |--------------------------------------------------------------------------
-    |
-    | These middleware will be assigned to every Telescope route, giving you
-    | the chance to add your own middleware to this list or change any of
-    | the existing middleware. Or, you can simply stick with this list.
-    |
-    */
-
     'middleware' => [
         'web',
         Authorize::class,
     ],
-
-    /*
-    |--------------------------------------------------------------------------
-    | Allowed / Ignored Paths & Commands
-    |--------------------------------------------------------------------------
-    |
-    | The following array lists the URI paths and Artisan commands that will
-    | not be watched by Telescope. In addition to this list, some Laravel
-    | commands, like migrations and queue commands, are always ignored.
-    |
-    */
 
     'only_paths' => [
         // 'api/*'
@@ -117,19 +37,19 @@ return [
     ],
 
     'ignore_commands' => [
-        //
+        'migrate',
+        'migrate:rollback',
+        'migrate:fresh',
+        'migrate:reset',
+        'migrate:install',
+        'db:seed',
+        'package:discover',
+        'queue:listen',
+        'queue:work',
+        'horizon',
+        'horizon:work',
+        'horizon:supervisor',
     ],
-
-    /*
-    |--------------------------------------------------------------------------
-    | Telescope Watchers
-    |--------------------------------------------------------------------------
-    |
-    | The following array lists the "watchers" that will be registered with
-    | Telescope. The watchers gather the application's profile data when
-    | a request or task is executed. Feel free to customize this list.
-    |
-    */
 
     'watchers' => [
         Watchers\BatchWatcher::class => env('TELESCOPE_BATCH_WATCHER', true),
@@ -199,6 +119,7 @@ return [
         ],
 
         Watchers\ScheduleWatcher::class => env('TELESCOPE_SCHEDULE_WATCHER', true),
+
         Watchers\ViewWatcher::class => env('TELESCOPE_VIEW_WATCHER', true),
     ],
 ];

--- a/docker/laravel-worker/Dockerfile
+++ b/docker/laravel-worker/Dockerfile
@@ -16,9 +16,7 @@ WORKDIR /app
 ################
 FROM base AS dev
 
-# Xdebug exists, but is explicitly disabled on workers.  Use docker-compose.override.yml to enable.
 RUN install-php-extensions xdebug
-RUN sed -i 's/^/#/' /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini
 
 USER app
 

--- a/docker/webapp/Dockerfile
+++ b/docker/webapp/Dockerfile
@@ -3,7 +3,8 @@ FROM dunglas/frankenphp:1.4.1-php8.4.3-bookworm AS base
 COPY --from=composer:2.8.5 /usr/bin/composer /usr/bin/composer
 ADD --chmod=0755 https://github.com/mlocati/docker-php-extension-installer/releases/download/2.7.14/install-php-extensions /usr/local/bin/
 
-RUN apt update && apt install -y bash zip
+# yes, vim, even on prod.  sudo is disabled anyway, so it can't do much damage.
+RUN apt update && apt install -y bash vim zip
 
 RUN install-php-extensions pdo pdo_pgsql zip intl redis
 


### PR DESCRIPTION
# Pull Request

## What changed?

* Adds a default of 'wp_org' for the `repository` field on Asset.  The new DB schema adds this as a column default so it won't be necessary in the model, but til that's merged, this will fix download issues.
* The .env file is no longer included in the container image.  It was doing things like setting APP_DEBUG to true because it's always a copy of the local dev machine's .env file, and there is no entry in the values+configmap to set it in the real environment (that will be fixed separately)
* Disables telescope by default in the config.  This crappy default is on the telescope devs for delivering that way, but I guess they got too many support requests from drooling morons who never changed the defaults -- as opposed to _this_ drooling moron who also didn't change the default.
* Adds vim to the container images, which is not really great practice, but useful for on-the-spot debugging during the beta period.  There is no sudo in the image (and it wouldn't work on the k8s cluster anyway) so it can't really do much damage.

## Why did it change?

Fixes the download issue in all environments, and improves security and performance for prod.

## Did you fix any specific issues?

none.  h/t to @costdev for the bug reports.

## CERTIFICATION

By opening this pull request, I do agree to abide by the [Code of Conduct](https://github.com/aspirepress/.github/blob/updating-contributor-policy/CODE_OF_CONDUCT.md) and be bound by the terms of the [Contribution Guidelines](https://github.com/aspirepress/.github/blob/updating-contributor-policy/CONTRIBUTING.md) in effect on the date and time of my contribution as proven by the revision information in GitHub.

