### PR TITLE
Update Dockerfiles and fill out php.ini 

### DIFF
--- a/app/Actions/Admin/API/V1/BulkImport.php
+++ b/app/Actions/Admin/API/V1/BulkImport.php
@@ -27,6 +27,7 @@ class BulkImport
     public function __invoke(Request $request, Pipeline $pipeline): JsonResponse
     {
         ini_set('memory_limit', '2G');
+        ini_set('max_execution_time', '300');
 
         $currentLine = 0;
         $imported = 0;

--- a/docker/cli/Dockerfile
+++ b/docker/cli/Dockerfile
@@ -1,9 +1,9 @@
-FROM php:8.3-cli AS base
+FROM php:8.4-cli AS base
 
-COPY --from=composer:2.8.3 /usr/bin/composer /usr/bin/composer
-ADD --chmod=0755 https://github.com/mlocati/docker-php-extension-installer/releases/download/2.5.2/install-php-extensions /usr/local/bin/
+COPY --from=composer:2.8.5 /usr/bin/composer /usr/bin/composer
+ADD --chmod=0755 https://github.com/mlocati/docker-php-extension-installer/releases/download/2.7.14/install-php-extensions /usr/local/bin/
 
-RUN apt update && apt install -y bash git postgresql-client zip
+RUN apt update && apt install -y bash git postgresql-client vim zip
 
 RUN install-php-extensions pdo pdo_pgsql zip intl redis
 
@@ -18,9 +18,7 @@ FROM base AS dev
 
 RUN apt update && apt install -y nodejs npm
 
-# Xdebug exists, but is explicitly disabled for cli.  Use docker-compose.override.yml to enable.
 RUN install-php-extensions xdebug
-RUN sed -i 's/^/#/' /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini
 
 USER app
 

--- a/docker/cli/php.ini
+++ b/docker/cli/php.ini
@@ -1,5 +1,42 @@
-error_reporting=E_ALL & ~E_DEPRECATED
+max_execution_time = 30
+memory_limit = 256M
+post_max_size = 20M
+upload_max_filesize = 20M
+max_file_uploads = 20
 
-[xdebug]
-xdebug.client_host=host.docker.internal
-xdebug.mode=develop
+
+error_reporting = E_ALL
+; error_reporting = E_ALL & ~E_DEPRECATED
+
+display_errors = Off
+display_startup_errors = Off
+log_errors = On
+error_log = /dev/stderr
+
+allow_url_fopen = On
+allow_url_include = Off
+expose_php = Off
+register_argc_argv = Off
+request_order = "GP"
+variables_order = "EGPCS"
+short_open_tag = Off
+html_errors = Off
+
+; disable_functions = mail
+
+;;;;;;;;;;;;;;;;
+
+;; We don't do much with sessions since we don't use the default session implementation anyway
+session.gc_divisor = 1000
+session.use_strict_mode = On
+
+user_ini.filename = None
+
+zend.assertions = 1                 ; best practice is to never disable assertions, especially not on prod!
+zend.exception_ignore_args = false  ; we disable reporting exceptions on prod, making it safe to keep the args
+zend.exception_string_param_max_len = 255 ; default is a stingy 15
+
+opcache.enable=1
+
+xdebug.client_host = host.docker.internal
+xdebug.mode = develop

--- a/docker/laravel-worker/Dockerfile
+++ b/docker/laravel-worker/Dockerfile
@@ -5,7 +5,7 @@ ADD --chmod=0755 https://github.com/mlocati/docker-php-extension-installer/relea
 
 RUN apt update && apt install -y bash git postgresql-client zip
 
-RUN install-php-extensions pdo pdo_pgsql zip intl redis
+RUN install-php-extensions pdo pdo_pgsql zip intl opcache redis
 
 COPY ./docker/cli/php.ini /usr/local/etc/php/php.ini
 

--- a/docker/laravel-worker/php.ini
+++ b/docker/laravel-worker/php.ini
@@ -1,5 +1,42 @@
-error_reporting=E_ALL & ~E_DEPRECATED
+max_execution_time = 30
+memory_limit = 256M
+post_max_size = 20M
+upload_max_filesize = 20M
+max_file_uploads = 20
 
-[xdebug]
-xdebug.client_host=host.docker.internal
-xdebug.mode=develop
+
+error_reporting = E_ALL
+; error_reporting = E_ALL & ~E_DEPRECATED
+
+display_errors = Off
+display_startup_errors = Off
+log_errors = On
+error_log = /dev/stderr
+
+allow_url_fopen = On
+allow_url_include = Off
+expose_php = Off
+register_argc_argv = Off
+request_order = "GP"
+variables_order = "EGPCS"
+short_open_tag = Off
+html_errors = Off
+
+; disable_functions = mail
+
+;;;;;;;;;;;;;;;;
+
+;; We don't do much with sessions since we don't use the default session implementation anyway
+session.gc_divisor = 1000
+session.use_strict_mode = On
+
+user_ini.filename = None
+
+zend.assertions = 1                 ; best practice is to never disable assertions, especially not on prod!
+zend.exception_ignore_args = false  ; we disable reporting exceptions on prod, making it safe to keep the args
+zend.exception_string_param_max_len = 255 ; default is a stingy 15
+
+opcache.enable=1
+
+xdebug.client_host = host.docker.internal
+xdebug.mode = develop

--- a/docker/webapp/Dockerfile
+++ b/docker/webapp/Dockerfile
@@ -6,7 +6,9 @@ ADD --chmod=0755 https://github.com/mlocati/docker-php-extension-installer/relea
 # yes, vim, even on prod.  sudo is disabled anyway, so it can't do much damage.
 RUN apt update && apt install -y bash vim zip
 
-RUN install-php-extensions pdo pdo_pgsql zip intl redis
+RUN install-php-extensions pdo pdo_pgsql zip intl opcache redis
+
+RUN cp /etc/caddy/Caddyfile /etc/caddy/Caddyfile.bak
 
 COPY ./docker/webapp/Caddyfile /etc/caddy/Caddyfile
 COPY ./docker/webapp/php.ini /usr/local/etc/php/php.ini

--- a/docker/webapp/php.ini
+++ b/docker/webapp/php.ini
@@ -1,5 +1,42 @@
-error_reporting=E_ALL & ~E_DEPRECATED
+max_execution_time = 30
+memory_limit = 256M
+post_max_size = 20M
+upload_max_filesize = 20M
+max_file_uploads = 20
 
-[xdebug]
-xdebug.client_host=host.docker.internal
-xdebug.mode=develop
+
+error_reporting = E_ALL
+; error_reporting = E_ALL & ~E_DEPRECATED
+
+display_errors = Off
+display_startup_errors = Off
+log_errors = On
+error_log = /dev/stderr
+
+allow_url_fopen = On
+allow_url_include = Off
+expose_php = Off
+register_argc_argv = Off
+request_order = "GP"
+variables_order = "EGPCS"
+short_open_tag = Off
+html_errors = Off
+
+; disable_functions = mail
+
+;;;;;;;;;;;;;;;;
+
+;; We don't do much with sessions since we don't use the default session implementation anyway
+session.gc_divisor = 1000
+session.use_strict_mode = On
+
+user_ini.filename = None
+
+zend.assertions = 1                 ; best practice is to never disable assertions, especially not on prod!
+zend.exception_ignore_args = false  ; we disable reporting exceptions on prod, making it safe to keep the args
+zend.exception_string_param_max_len = 255 ; default is a stingy 15
+
+opcache.enable=1
+
+xdebug.client_host = host.docker.internal
+xdebug.mode = develop


### PR DESCRIPTION
# Pull Request

## What changed?

* xdebug is enabled by default in all dev containers, since its default mode is just `develop` which adds minimal overhead and no annoying error messages when the listener is off.
* the BulkImport admin action now has a timeout of 5 minutes instead of 30 seconds.
* php.ini is less minimal than before, with sensible defaults for our setup, including enabling full error tracebacks since they're never displayed to users anyway.

## Why did it change?

bugs gotta be squished.

## Did you fix any specific issues?

none

## CERTIFICATION

By opening this pull request, I do agree to abide by the [Code of Conduct](https://github.com/aspirepress/.github/blob/updating-contributor-policy/CODE_OF_CONDUCT.md) and be bound by the terms of the [Contribution Guidelines](https://github.com/aspirepress/.github/blob/updating-contributor-policy/CONTRIBUTING.md) in effect on the date and time of my contribution as proven by the revision information in GitHub.

