### PR TITLE
CI: drop pint from CI tests

### DIFF
--- a/.github/workflows/run-checks.yaml
+++ b/.github/workflows/run-checks.yaml
@@ -29,6 +29,14 @@ jobs:
 
       - name: Run tests
         run: |
-          vendor/bin/pint --test
           vendor/bin/phpstan --memory-limit=1G analyse
           php artisan test tests/Unit
+
+      # [chuck 2025-02-06] Removed pint.  Its not only grotesquely slow, it doesn't even fix things in one pass.
+      # If we're going to have style wars, I'd rather it were between humans and not within one insane formatter.
+
+      # - name: Run tests
+      #   run: |
+      #     vendor/bin/pint --test
+      #     vendor/bin/phpstan --memory-limit=1G analyse
+      #     php artisan test tests/Unit


### PR DESCRIPTION
# Pull Request

## What changed?

This takes out the call to `pint --test` from CI.

## Why did it change?

Not only does pint, or the real culprit, php-cs-fixer, take longer to run than phpstan, it doesn't even produce stable results: too many times I've had pint "fix" a file, then it fails the test again!

Formatting checks in CI are a good thing, but not if it's like this.  Pint is still in the composer dependencies, so I'll just commit the occasional mass-reformat by hand.  sic transit pint.

## Did you fix any specific issues?

No GH issues, but my blood pressure is probably lower now.

## CERTIFICATION

By opening this pull request, I do agree to abide by the [Code of Conduct](https://github.com/aspirepress/.github/blob/updating-contributor-policy/CODE_OF_CONDUCT.md) and be bound by the terms of the [Contribution Guidelines](https://github.com/aspirepress/.github/blob/updating-contributor-policy/CONTRIBUTING.md) in effect on the date and time of my contribution as proven by the revision information in GitHub.

