### PR TITLE
fix: replace downloadurl_placeholder with download_link

### DIFF
--- a/app/Data/WpOrg/Themes/ThemeUpdateData.php
+++ b/app/Data/WpOrg/Themes/ThemeUpdateData.php
@@ -18,9 +18,6 @@ class ThemeUpdateData extends Data
         public ?string $requires_php,
     ) {}
 
-    /**
-     * Static method to create an instance from a Theme model.
-     */
     public static function fromModel(Theme $theme): self
     {
         return new self(
@@ -28,22 +25,18 @@ class ThemeUpdateData extends Data
             theme: $theme->slug,
             new_version: $theme->version,
             url: $theme->download_link,
-            package: "downloadurl_placeholder{$theme->version}",
-            // requires: $theme->requires['wordpress'] ?? null, // XXX HUH?  requires is always a string...
+            package: $theme->download_link,
             requires: $theme->requires,
             requires_php: $theme->requires_php,
         );
     }
 
     /**
-     * Static method to create an instance from a Theme model.
      * @param Collection<int,Theme> $themes
      * @return Collection<string,ThemeUpdateData>
      */
     public static function fromModelCollection(Collection $themes): Collection
     {
-        return $themes->mapWithKeys(fn($theme) => [
-            $theme->slug => self::fromModel($theme),
-        ]);
+        return $themes->mapWithKeys(fn($theme) => [$theme->slug => self::fromModel($theme)]);
     }
 }

--- a/bruno/Plugins/Plugins Update Check.bru
+++ b/bruno/Plugins/Plugins Update Check.bru
@@ -4,7 +4,7 @@ meta {
   seq: 2
 }
 
-get {
+post {
   url: {{API_URL}}/plugins/update-check/:api_version
   body: formUrlEncoded
   auth: none
@@ -15,7 +15,6 @@ params:path {
 }
 
 headers {
-  Host: api.wordpress.org
   User-Agent: WordPress/6.2.2; http://172.18.0.5/
   Accept: */*
   Accept-Encoding: deflate, gzip

--- a/bruno/Themes/Themes Update Check.bru
+++ b/bruno/Themes/Themes Update Check.bru
@@ -15,7 +15,6 @@ params:path {
 }
 
 headers {
-  Host: api.wordpress.org
   User-Agent: WordPress/6.2.2; http://172.18.0.5/
   Accept: */*
   Accept-Encoding: deflate, gzip

--- a/bruno/collection.bru
+++ b/bruno/collection.bru
@@ -1,9 +1,5 @@
-headers {
-  Authorization: Bearer {{API_KEY}}
-}
-
 docs {
   [Public docs are on the Codex](https://codex.wordpress.org/WordPress.org_API)
-
+  
   We can use [OpenAPI Mocker](https://www.npmjs.com/package/open-api-mocker) for using a mock server
 }

--- a/bruno/environments/AspireCloud Production API.bru
+++ b/bruno/environments/AspireCloud Production API.bru
@@ -1,4 +1,4 @@
 vars {
-  API_URL: https://api.aspirecloud.org
-  DOWNLOADS_URL: https://downloads.aspirecloud.org
+  API_URL: https://api.aspirecloud.net
+  DOWNLOADS_URL: https://downloads.aspirecloud.net
 }

--- a/bruno/environments/AspireCloud Staging API.bru
+++ b/bruno/environments/AspireCloud Staging API.bru
@@ -1,0 +1,3 @@
+vars {
+  API_URL: https://api.aspirecloud.io
+}

--- a/tests/Feature/API/WpOrg/ApiAuthenticationTest.php
+++ b/tests/Feature/API/WpOrg/ApiAuthenticationTest.php
@@ -11,4 +11,3 @@ it('should return 401 when an invalid auth token is present', function () {
 });
 
 // TODO: write test for real auth token
-

--- a/tests/Feature/API/WpOrg/ThemeUpdateControllerTest.php
+++ b/tests/Feature/API/WpOrg/ThemeUpdateControllerTest.php
@@ -102,46 +102,42 @@ it('returns theme updates', function () {
                     "Stylesheet" => "my-theme",
                 ],
             ],
-        ]), 'translations' => "[]",
+        ]),
+        'translations' => "[]",
         'locale' => "[\"en_US\"]",
     ], [
         'Accept' => 'application/json',
     ]);
 
     $response->assertStatus(200);
-    $response->assertJsonCount(1, 'themes')
+    $response
+        ->assertJsonCount(1, 'themes')
         ->assertJsonCount(1, 'no_update')
-        ->assertJsonStructure([
+        ->assertJson([
             'themes' => [
                 'my-theme' => [
-                    'name',
-                    'new_version',
-                    'package',
-                    'requires',
-                    'requires_php',
-                    'theme',
-                    'url',
+                    'name' => 'My Theme',
+                    'theme' => 'my-theme',
+                    'new_version' => '1.2.1',
+                    'url' => 'https://api.aspiredev.org/download/my-theme',
+                    'package' => 'https://api.aspiredev.org/download/my-theme',
+                    'requires' => null,
+                    'requires_php' => '5.6',
                 ],
             ],
             'no_update' => [
                 'my-theme2' => [
-                    'name',
-                    'new_version',
-                    'package',
-                    'requires',
-                    'requires_php',
-                    'theme',
-                    'url',
+                    'name' => 'My Theme2',
+                    'theme' => 'my-theme2',
+                    'new_version' => '2.9',
+                    'url' => 'https://api.aspiredev.org/download/my-theme2',
+                    'package' => 'https://api.aspiredev.org/download/my-theme2',
+                    'requires' => null,
+                    'requires_php' => '5.6',
                 ],
             ],
-            'translations',
-        ])
-        ->assertJsonPath('themes.my-theme.name', 'My Theme')
-        ->assertJsonPath('themes.my-theme.new_version', '1.2.1')
-        ->assertJsonPath('themes.my-theme.theme', 'my-theme')
-        ->assertJsonPath('no_update.my-theme2.name', 'My Theme2')
-        ->assertJsonPath('no_update.my-theme2.new_version', '2.9')
-        ->assertJsonPath('no_update.my-theme2.theme', 'my-theme2');
+            'translations' => [],
+        ]);
 });
 
 it('returns theme updates - no_updates', function () {
@@ -170,43 +166,39 @@ it('returns theme updates - no_updates', function () {
                     "Stylesheet" => "my-theme",
                 ],
             ],
-        ]), 'translations' => "[]",
+        ]),
+        'translations' => "[]",
         'locale' => "[\"en_US\"]",
     ], [
         'Accept' => 'application/json',
     ]);
 
     $response->assertStatus(200);
-    $response->assertJsonCount(0, 'themes')
+    $response
+        ->assertJsonCount(0, 'themes')
         ->assertJsonCount(2, 'no_update')
-        ->assertJsonStructure([
-            'themes',
+        ->assertJson([
+            'themes' => [],
             'no_update' => [
                 'my-theme' => [
-                    'name',
-                    'new_version',
-                    'package',
-                    'requires',
-                    'requires_php',
-                    'theme',
-                    'url',
+                    'name' => 'My Theme',
+                    'theme' => 'my-theme',
+                    'new_version' => '1.2.1',
+                    'url' => 'https://api.aspiredev.org/download/my-theme',
+                    'package' => 'https://api.aspiredev.org/download/my-theme',
+                    'requires' => null,
+                    'requires_php' => '5.6',
                 ],
                 'my-theme2' => [
-                    'name',
-                    'new_version',
-                    'package',
-                    'requires',
-                    'requires_php',
-                    'theme',
-                    'url',
+                    'name' => 'My Theme2',
+                    'theme' => 'my-theme2',
+                    'new_version' => '2.9',
+                    'url' => 'https://api.aspiredev.org/download/my-theme2',
+                    'package' => 'https://api.aspiredev.org/download/my-theme2',
+                    'requires' => null,
+                    'requires_php' => '5.6',
                 ],
             ],
-            'translations',
-        ])
-        ->assertJsonPath('no_update.my-theme.name', 'My Theme')
-        ->assertJsonPath('no_update.my-theme.new_version', '1.2.1')
-        ->assertJsonPath('no_update.my-theme.theme', 'my-theme')
-        ->assertJsonPath('no_update.my-theme2.name', 'My Theme2')
-        ->assertJsonPath('no_update.my-theme2.new_version', '2.9')
-        ->assertJsonPath('no_update.my-theme2.theme', 'my-theme2');
+            'translations' => [],
+        ]);
 });


### PR DESCRIPTION
# Pull Request

## What changed?

* Replaced the placeholder in theme update responses with download_link.

* updates tests to ensure download_link was used.

* Various fixes and updates to bruno tests that had to be done alone the way

## Why did it change?

obvious bugfix is obvious

## Did you fix any specific issues?

none. 

## CERTIFICATION

By opening this pull request, I do agree to abide by the [Code of Conduct](https://github.com/aspirepress/.github/blob/updating-contributor-policy/CODE_OF_CONDUCT.md) and be bound by the terms of the [Contribution Guidelines](https://github.com/aspirepress/.github/blob/updating-contributor-policy/CONTRIBUTING.md) in effect on the date and time of my contribution as proven by the revision information in GitHub.

