### PR TITLE
Determine asset content-type from extension

### DIFF
--- a/app/Models/WpOrg/Asset.php
+++ b/app/Models/WpOrg/Asset.php
@@ -4,6 +4,7 @@ namespace App\Models\WpOrg;
 
 use App\Enums\AssetType;
 use App\Events\AssetCreated;
+use App\Utils\Regex;
 use Carbon\CarbonImmutable;
 use Database\Factories\WpOrg\AssetFactory;
 use Illuminate\Database\Eloquent\Concerns\HasUuids;
@@ -54,4 +55,21 @@ class Asset extends Model
     protected $attributes = [
         'repository' => 'wp_org', // this is the db default as well since 0.9.3, but it's handy to have it here too
     ];
+
+    public function getContentType(): string
+    {
+        $matches = Regex::match('/^.+\.(\w+)$/', $this->local_path);
+        if (!$matches) {
+            return 'application/octet-stream';
+        }
+        // hardly exhaustive, but enough to cover our assets ;)
+        return match ($matches[1]) {
+            'zip' => 'application/zip',
+            'png' => 'image/png',
+            'jpg', 'jpeg' => 'image/jpeg',
+            'gif' => 'image/gif',
+            'svg' => 'image/svg+xml',
+            default => 'application/octet-stream',
+        };
+    }
 }

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -18,6 +18,11 @@ class AppServiceProvider extends ServiceProvider
 
     public function boot(): void
     {
+        if (!config('app.report_deprecations')) {
+            // Both Laravel and Symfony try to force error_reporting(-1) with no way out, and it's super annoying.
+            error_reporting(E_ALL & ~E_DEPRECATED);
+        }
+
         $isDev = !$this->app->isProduction();
 
         // SSL termination means $request->getScheme() is always 'http', so prevent mixed content problems here.

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -1,11 +1,15 @@
 <?php
 
+// This one file should contain all boot-time actions relevant to the app.
+// There should be no need to create more ServiceProviders, unless for an actually separable concern.
+
 namespace App\Providers;
 
 use App\Auth\Role;
 use App\Models\User;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Facades\Gate;
+use Illuminate\Support\Facades\Route;
 use Illuminate\Support\Facades\URL;
 use Illuminate\Support\ServiceProvider;
 
@@ -13,7 +17,7 @@ class AppServiceProvider extends ServiceProvider
 {
     public function register(): void
     {
-        //
+        // Put only DI container bindings here, if and when they're needed.
     }
 
     public function boot(): void
@@ -23,17 +27,24 @@ class AppServiceProvider extends ServiceProvider
             error_reporting(E_ALL & ~E_DEPRECATED);
         }
 
-        $isDev = !$this->app->isProduction();
-
         // SSL termination means $request->getScheme() is always 'http', so prevent mixed content problems here.
         if (str_starts_with(config('app.url'), 'https')) {
             URL::forceScheme('https');
         }
 
+        $isDev = !$this->app->isProduction();
         Model::preventLazyLoading($isDev);
         Model::preventSilentlyDiscardingAttributes($isDev);
 
         // SuperAdmins bypass all auth checks
         Gate::before(fn(User $user) => $user->hasRole(Role::SuperAdmin) ?: null);
+
+        // make a vague stab at functional abstraction ;)
+        $this->bootRoutes();
+    }
+
+    private function bootRoutes(): void
+    {
+        Route::pattern('slug', '[-_A-Za-z0-9]+'); // underscore is uncommon, but some assets do use it.
     }
 }

--- a/app/Services/Downloads/DownloadService.php
+++ b/app/Services/Downloads/DownloadService.php
@@ -38,7 +38,7 @@ class DownloadService implements Downloader
             $stream = Storage::disk('s3')->getDriver()->readStream($asset->local_path);
             return response()->stream(
                 fn() => fpassthru($stream),
-                headers: ['Content-Type' => 'application/octet-stream'],
+                headers: ['Content-Type' => $asset->getContentType()],
             );
         }
 

--- a/bin/dbsh
+++ b/bin/dbsh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+cd $(dirname $0)/..
+
+# allow real environment variables to override .env
+orig_pgdatabase=${PGDATABASE:-$DB_DATABASE}
+orig_pghost=${PGHOST:-$DB_HOST}
+orig_pgpassword=${PGPASSWORD:-$DB_PASSWORD}
+orig_pgport=${PGPORT:-$DB_PORT}
+orig_pguser=${PGUSER:-$DB_USERNAME}
+
+[[ -f .env ]] && source .env
+
+# note we don't respect PG* variables set in .env, since it should only have variables used by Laravel
+export PGDATABASE=${orig_pgdatabase:-$DB_DATABASE}
+export PGHOST=${orig_pghost:-$DB_HOST}
+export PGPASSWORD=${orig_pgpassword:-$DB_PASSWORD}
+export PGPORT=${orig_pgport:-$DB_PORT}
+export PGUSER=${orig_pguser:-$DB_USERNAME}
+
+exec psql "$@"

--- a/routes/inc/download.php
+++ b/routes/inc/download.php
@@ -24,26 +24,26 @@ Route::prefix('/')
 
         $router
             ->get('/download/plugin/{file}', DownloadPluginController::class)
-            ->where('file', '.+\.zip')
+            ->where(['file' => '.+\.zip'])
             ->name('download.plugin');
 
         $router
             ->get('/download/theme/{file}', DownloadThemeController::class)
-            ->where('file', '.+\.zip')
+            ->where(['file' => '.+\.zip'])
             ->name('download.theme');
 
         $router
             ->get('/download/assets/plugin/{slug}/{revision}/{file}', DownloadPluginAssetController::class)
-            ->where(['slug' => '[a-zA-Z0-9-]+', 'file' => '.+'])
+            ->where(['file' => '.+'])
             ->name('download.plugin.asset');
 
         $router
             ->get('/download/gp-icon/plugin/{slug}/{revision}/{file}', DownloadPluginIconController::class)
-            ->where(['slug' => '[a-zA-Z0-9-]+', 'file' => '.+'])
+            ->where(['file' => '.+'])
             ->name('download.plugin.gp-icon');
 
         $router
             ->get('/download/assets/theme/{slug}/{revision}/{file}', DownloadThemeScreenshotController::class)
-            ->where(['slug' => '[a-zA-Z0-9-]+', 'file' => '.+'])
+            ->where(['file' => '.+'])
             ->name('download.theme.asset');
     });


### PR DESCRIPTION
# Pull Request

## What changed?

* Uses the file extension in assets to determine their content type instead of hardwiring application/octet-stream
* Underscores are now allowed in download slug patterns.

Unrelated changes
* `error_reporting(E_ALL & ~E_DEPRECATED)` is now enabled in ApplicationServiceProvider unless specifically overridden in config to remain at E_ALL.  Laravel and Symfony both insist on spamming stderr with deprecations I can't do anything about until packages update.  No more of that nonsense.

* new `bin/dbsh` script to get a postgres prompt based on the DB_* variables in .env.  Unlike `php artisan db` this takes arbitrary psql cli arguments, and it's much faster to start.

## Why did it change?

Images in browsers are broken without the proper content type.  The other things are just necessary gardening.

## Did you fix any specific issues?

Closes: #150 

## CERTIFICATION

By opening this pull request, I do agree to abide by the [Code of Conduct](https://github.com/aspirepress/.github/blob/updating-contributor-policy/CODE_OF_CONDUCT.md) and be bound by the terms of the [Contribution Guidelines](https://github.com/aspirepress/.github/blob/updating-contributor-policy/CONTRIBUTING.md) in effect on the date and time of my contribution as proven by the revision information in GitHub.

