### PR TITLE
fix: convert all routes on CatchAllController to take any http method

### DIFF
--- a/routes/api.php
+++ b/routes/api.php
@@ -25,25 +25,27 @@ Route::prefix('/')
         $router->get('/secret-key/{version}', [SecretKeyController::class, 'index'])->where(['version' => '1.[01]']);
         $router->get('/secret-key/{version}/salt', [SecretKeyController::class, 'salt'])->where(['version' => '1.1']);
 
-        $router->get('/stats/wordpress/{version}', CatchAllController::class)->where(['version' => '1.0']);
-        $router->get('/stats/php/{version}', CatchAllController::class)->where(['version' => '1.0']);
-        $router->get('/stats/mysql/{version}', CatchAllController::class)->where(['version' => '1.0']);
-        $router->get('/stats/locale/{version}', CatchAllController::class)->where(['version' => '1.0']);
-        $router->get('/stats/plugin/{version}/downloads.php', CatchAllController::class)->where(['version' => '1.0']);
-        $router->get('/stats/plugin/{version}/{slug}', CatchAllController::class)->where(['version' => '1.0']);
+        $router->any('/stats/wordpress/{version}', CatchAllController::class)->where(['version' => '1.0']);
+        $router->any('/stats/php/{version}', CatchAllController::class)->where(['version' => '1.0']);
+        $router->any('/stats/mysql/{version}', CatchAllController::class)->where(['version' => '1.0']);
+        $router->any('/stats/locale/{version}', CatchAllController::class)->where(['version' => '1.0']);
+        $router->any('/stats/plugin/{version}/downloads.php', CatchAllController::class)->where(['version' => '1.0']);
+        $router->any('/stats/plugin/{version}/{slug}', CatchAllController::class)->where(['version' => '1.0']);
 
-        $router->get('/core/browse-happy/{version}', CatchAllController::class)->where(['version' => '1.1']);
-        $router->get('/core/checksums/{version}', CatchAllController::class)->where(['version' => '1.0']);
-        $router->get('/core/credits/{version}', CatchAllController::class)->where(['version' => '1.[01]']);
-        $router->get('/core/handbook/{version}', CatchAllController::class)->where(['version' => '1.0']);
+        $router->any('/core/browse-happy/{version}', CatchAllController::class)->where(['version' => '1.1']);
+        $router->any('/core/checksums/{version}', CatchAllController::class)->where(['version' => '1.0']);
+        $router->any('/core/credits/{version}', CatchAllController::class)->where(['version' => '1.[01]']);
+        $router->any('/core/handbook/{version}', CatchAllController::class)->where(['version' => '1.0']);
+
         $router->get('/core/importers/{version}', ImportersController::class)->where(['version' => '1.[01]']);
-        $router->get('/core/serve-happy/{version}', CatchAllController::class)->where(['version' => '1.0']);
-        $router->get('/core/stable-check/{version}', CatchAllController::class)->where(['version' => '1.0']);
-        $router->get('/core/version-check/{version}', CatchAllController::class)->where(['version' => '1.[67]']);
 
-        $router->get('/translations/core/{version}', CatchAllController::class)->where(['version' => '1.0']);
-        $router->get('/translations/plugins/{version}', CatchAllController::class)->where(['version' => '1.0']);
-        $router->get('/translations/themes/{version}', CatchAllController::class)->where(['version' => '1.0']);
+        $router->any('/core/serve-happy/{version}', CatchAllController::class)->where(['version' => '1.0']);
+        $router->any('/core/stable-check/{version}', CatchAllController::class)->where(['version' => '1.0']);
+        $router->any('/core/version-check/{version}', CatchAllController::class)->where(['version' => '1.[67]']);
+
+        $router->any('/translations/core/{version}', CatchAllController::class)->where(['version' => '1.0']);
+        $router->any('/translations/plugins/{version}', CatchAllController::class)->where(['version' => '1.0']);
+        $router->any('/translations/themes/{version}', CatchAllController::class)->where(['version' => '1.0']);
 
         $router->get('/themes/info/{version}', [ThemeController::class, 'info'])->where(['version' => '1.[012]']);
         $router->match(['get', 'post'], '/themes/update-check/{version}', ThemeUpdatesController::class)->where(
@@ -51,13 +53,13 @@ Route::prefix('/')
         );
 
         $router->get('/plugins/info/1.2', PluginInformation_1_2_Controller::class);
-        $router->get('/plugins/info/{version}', CatchAllController::class)->where(['version' => '1.[01]']);
+        $router->any('/plugins/info/{version}', CatchAllController::class)->where(['version' => '1.[01]']);
 
         $router->post('/plugins/update-check/1.1', PluginUpdateCheck_1_1_Controller::class);
-        $router->get('/plugins/update-check/{version}', CatchAllController::class)->where(['version' => '1.0']);
+        $router->any('/plugins/update-check/{version}', CatchAllController::class)->where(['version' => '1.0']);
 
-        $router->get('/patterns/{version}', CatchAllController::class)->where(['version' => '1.0']);
-        $router->get('/events/{version}', CatchAllController::class)->where(['version' => '1.0']);
+        $router->any('/patterns/{version}', CatchAllController::class)->where(['version' => '1.0']);
+        $router->any('/events/{version}', CatchAllController::class)->where(['version' => '1.0']);
     });
 
 // Route::any('{path}', CatchAllController::class)->where('path', '.*');


### PR DESCRIPTION
# Pull Request

## What changed?

All the $router->get routes that pass through to CatchAllController now use $router->any instead

## Why did it change?

Some of these endpoints do take a POST, we don't want to break WP for those.

## Did you fix any specific issues?

none.  h/t to @costdev for the report

## CERTIFICATION

By opening this pull request, I do agree to abide by the [Code of Conduct](https://github.com/aspirepress/.github/blob/updating-contributor-policy/CODE_OF_CONDUCT.md) and be bound by the terms of the [Contribution Guidelines](https://github.com/aspirepress/.github/blob/updating-contributor-policy/CONTRIBUTING.md) in effect on the date and time of my contribution as proven by the revision information in GitHub.

