### PR TITLE
Smarter and faster plugin and themes searching

### DIFF
--- a/app/Services/Plugins/QueryPluginsService.php
+++ b/app/Services/Plugins/QueryPluginsService.php
@@ -75,7 +75,7 @@ class QueryPluginsService
     /** @param Builder<Plugin> $query */
     private static function applyAuthor(Builder $query, string $author): void
     {
-        $query->whereLike('author', $author);
+        $query->whereLike('author', "%{$author}%");
     }
 
     /** @param Builder<Plugin> $query */

--- a/app/Services/Plugins/QueryPluginsService.php
+++ b/app/Services/Plugins/QueryPluginsService.php
@@ -113,6 +113,7 @@ class QueryPluginsService
         }
         $search = trim($search);
         $search = Regex::replace('/\s+/i', ' ', $search);
-        return Regex::replace('/[^\w.,!?@#$_-]/i', ' ', $search); // strip most punctuation, allow a small subset
+        $search = Regex::replace('/[^\w.,!?@#$_-]/i', ' ', $search); // strip most punctuation, allow a small subset
+        return Regex::replace('/-+/', '-', $search);                 // collapse any consecutive dashes from the above
     }
 }

--- a/app/Services/Plugins/QueryPluginsService.php
+++ b/app/Services/Plugins/QueryPluginsService.php
@@ -28,6 +28,8 @@ class QueryPluginsService
         string $browse = 'popular',
     ): array {
         $search = self::normalizeSearchString($search);
+        $tag = self::normalizeSearchString($tag);
+        $author = self::normalizeSearchString($author);
 
         $query = Plugin::query()
             ->when($browse, self::applyBrowse(...))
@@ -75,7 +77,7 @@ class QueryPluginsService
     /** @param Builder<Plugin> $query */
     private static function applyAuthor(Builder $query, string $author): void
     {
-        $query->whereLike('author', "%{$author}%");
+        $query->whereRaw("author %> '$author'");
     }
 
     /** @param Builder<Plugin> $query */

--- a/app/Services/Plugins/QueryPluginsService.php
+++ b/app/Services/Plugins/QueryPluginsService.php
@@ -62,6 +62,9 @@ class QueryPluginsService
 
         $q = Plugin::query();
 
+        // I can't make %> work this way, only whereRaw works.  TODO: find out why.
+        // $slug_similar = $q->clone()->where('slug', '%>', $search);
+
         $slug_similar = $q->clone()->whereRaw("slug %> '$search'");
         $name_exact = $q->clone()->where('name', $search);
         $name_similar = $q->clone()->whereRaw("name %> '$search'");

--- a/app/Services/Plugins/QueryPluginsService.php
+++ b/app/Services/Plugins/QueryPluginsService.php
@@ -43,7 +43,8 @@ class QueryPluginsService
         $plugins = $query
             ->offset(($page - 1) * $perPage)
             ->limit($perPage)
-            ->get();
+            ->get()
+            ->unique('slug');
 
         return [
             'plugins' => $plugins,

--- a/app/Services/Plugins/QueryPluginsService.php
+++ b/app/Services/Plugins/QueryPluginsService.php
@@ -113,7 +113,6 @@ class QueryPluginsService
         }
         $search = trim($search);
         $search = Regex::replace('/\s+/i', ' ', $search);
-        $search = Regex::replace('/[^\w.,!?@#$_-]/i', ' ', $search); // strip most punctuation, allow a small subset
-        return Regex::replace('/-+/', '-', $search);                 // collapse any consecutive dashes from the above
+        return Regex::replace('/[^\w.,!?@#$_-]/i', ' ', $search); // strip most punctuation, allow a small subset
     }
 }

--- a/app/Services/Themes/QueryThemesService.php
+++ b/app/Services/Themes/QueryThemesService.php
@@ -6,6 +6,7 @@ use App\Data\WpOrg\Themes\QueryThemesRequest;
 use App\Http\Resources\ThemeCollection;
 use App\Http\Resources\ThemeResource;
 use App\Models\WpOrg\Theme;
+use App\Utils\Regex;
 use Illuminate\Database\Eloquent\Builder;
 
 class QueryThemesService
@@ -16,12 +17,15 @@ class QueryThemesService
         $perPage = $req->per_page;
         $skip = ($page - 1) * $perPage;
 
+        $search = self::normalizeSearchString($req->search);
+        $author = self::normalizeSearchString($req->author);
+
         $themesBaseQuery = Theme::query()
             ->orderBy('last_updated', 'desc')   // default sort
             ->when($req->browse, self::applyBrowse(...))
-            ->when($req->search, self::applySearch(...))
+            ->when($search, self::applySearch(...))
             ->when($req->theme, self::applyTheme(...))
-            ->when($req->author, self::applyAuthor(...))
+            ->when($author, self::applyAuthor(...))
             ->when($req->tags, self::applyTags(...));
 
         $total = $themesBaseQuery->count();
@@ -52,22 +56,35 @@ class QueryThemesService
     /** @param Builder<Theme> $query */
     private static function applySearch(Builder $query, string $search): void
     {
-        $query
-            ->whereFullText('slug', $search)
-            ->orWhereFullText('name', $search)
-            ->orWhereFullText('description', $search);
+        $slug = Regex::replace('/[^a-z0-9-]+/i', '-', $search);
+        $query->where('slug', $slug); // need an initial condition or it retrieves everything
+
+        $q = Theme::query();
+
+        $slug_similar = $q->clone()->whereRaw("slug %> '$search'");
+        $name_exact = $q->clone()->where('name', $search);
+        $name_similar = $q->clone()->whereRaw("name %> '$search'");
+        $description_fulltext = $q->clone()->whereFullText('description', $search);
+
+        $query->unionAll($name_exact);
+        $query->unionAll($slug_similar);
+        $query->unionAll($name_similar);
+        $query->unionAll($description_fulltext);
     }
 
     /** @param Builder<Theme> $query */
     private static function applyTheme(Builder $query, string $theme): void
     {
-        $query->whereFullText('slug', $theme);
+        $query->whereRaw("slug %> '$theme'");
     }
 
     /** @param Builder<Theme> $query */
     private static function applyAuthor(Builder $query, string $author): void
     {
-        $query->whereHas('author', fn(Builder $q) => $q->where('user_nicename', 'like', "%$author%"));
+        $query->whereHas(
+            'author',
+            fn(Builder $q) => $q->whereRaw("user_nicename %> '$author'")->orWhereRaw("display_name %> '$author'"),
+        );
     }
 
     /**
@@ -77,5 +94,15 @@ class QueryThemesService
     private static function applyTags(Builder $query, array $tags): void
     {
         $query->whereHas('tags', fn(Builder $q) => $q->whereIn('slug', $tags));
+    }
+
+    private static function normalizeSearchString(?string $search): ?string
+    {
+        if ($search === null) {
+            return null;
+        }
+        $search = trim($search);
+        $search = Regex::replace('/\s+/i', ' ', $search);
+        return Regex::replace('/[^\w.,!?@#$_-]/i', ' ', $search); // strip most punctuation, allow a small subset
     }
 }

--- a/app/Services/Themes/QueryThemesService.php
+++ b/app/Services/Themes/QueryThemesService.php
@@ -104,6 +104,7 @@ class QueryThemesService
         }
         $search = trim($search);
         $search = Regex::replace('/\s+/i', ' ', $search);
-        return Regex::replace('/[^\w.,!?@#$_-]/i', ' ', $search); // strip most punctuation, allow a small subset
+        $search = Regex::replace('/[^\w.,!?@#$_-]/i', ' ', $search); // strip most punctuation, allow a small subset
+        return Regex::replace('/-+/', '-', $search);                 // collapse any consecutive dashes from the above
     }
 }

--- a/app/Services/Themes/QueryThemesService.php
+++ b/app/Services/Themes/QueryThemesService.php
@@ -37,6 +37,7 @@ class QueryThemesService
             ->get();
 
         $collection = collect($themes)
+            ->unique('slug')
             ->map(fn($theme) => (new ThemeResource($theme))->additional(['fields' => $req->fields]));
 
         return new ThemeCollection($collection, $page, (int) ceil($total / $perPage), $total);

--- a/app/Services/Themes/QueryThemesService.php
+++ b/app/Services/Themes/QueryThemesService.php
@@ -104,7 +104,6 @@ class QueryThemesService
         }
         $search = trim($search);
         $search = Regex::replace('/\s+/i', ' ', $search);
-        $search = Regex::replace('/[^\w.,!?@#$_-]/i', ' ', $search); // strip most punctuation, allow a small subset
-        return Regex::replace('/-+/', '-', $search);                 // collapse any consecutive dashes from the above
+        return Regex::replace('/[^\w.,!?@#$_-]/i', ' ', $search); // strip most punctuation, allow a small subset
     }
 }

--- a/app/Utils/Regex.php
+++ b/app/Utils/Regex.php
@@ -12,6 +12,11 @@ class Regex
         return $matches;
     }
 
+    public static function replace(string $pattern, string $replacement, string $subject, int $limit = -1): string
+    {
+        return \Safe\preg_replace($pattern, $replacement, $subject, $limit);
+    }
+
     private function __construct()
     {
         // not instantiable

--- a/database/migrations/2025_02_21_174738_add_trigram_indexes.php
+++ b/database/migrations/2025_02_21_174738_add_trigram_indexes.php
@@ -8,17 +8,31 @@ return new class extends Migration {
     public function up(): void
     {
         DB::raw('CREATE EXTENSION IF NOT EXISTS pg_trgm');
-        DB::raw('CREATE INDEX plugins_slug_trgm ON plugins USING GIST (slug gist_trgm_ops(siglen=48))');
-        DB::raw('CREATE INDEX plugins_name_trgm ON plugins USING GIST (name gist_trgm_ops(siglen=48))');
+        DB::raw('CREATE INDEX plugins_slug_trgm ON plugins USING GIST (slug gist_trgm_ops(siglen=32))');
+        DB::raw('CREATE INDEX plugins_name_trgm ON plugins USING GIST (name gist_trgm_ops(siglen=32))');
         DB::raw(
-            'CREATE INDEX plugins_short_description_trgm ON plugins USING GIST (short_description gist_trgm_ops(siglen=48))',
+            'CREATE INDEX plugins_short_description_trgm ON plugins USING GIST (short_description gist_trgm_ops(siglen=32))',
         );
+        DB::raw('CREATE INDEX plugins_author_trgm ON plugins USING GIST (author gist_trgm_ops(siglen=32))');
+
+        DB::raw('CREATE INDEX themes_slug_trgm ON themes USING GIST (slug gist_trgm_ops(siglen=32))');
+        DB::raw('CREATE INDEX themes_name_trgm ON themes USING GIST (name gist_trgm_ops(siglen=32))');
+
+        DB::raw(
+            'CREATE INDEX author_user_nicename_trgm on authors using GIST (user_nicename gist_trgm_ops(siglen=32))',
+        );
+        DB::raw('CREATE INDEX author_display_name_trgm on authors using GIST (display_name gist_trgm_ops(siglen=32))');
     }
 
     public function down(): void
     {
-        DB::raw('DROP INDEX plugins_short_description_trgm');
-        DB::raw('DROP INDEX plugins_name_trgm');
-        DB::raw('DROP INDEX plugins_slug_trgm');
+        DB::raw('DROP INDEX IF EXISTS author_display_name_trgm');
+        DB::raw('DROP INDEX IF EXISTS author_user_nicename_trgm');
+        DB::raw('DROP INDEX IF EXISTS themes_name_trgm');
+        DB::raw('DROP INDEX IF EXISTS themes_slug_trgm');
+        DB::raw('DROP INDEX IF EXISTS plugins_author_trgm');
+        DB::raw('DROP INDEX IF EXISTS plugins_short_description_trgm');
+        DB::raw('DROP INDEX IF EXISTS plugins_name_trgm');
+        DB::raw('DROP INDEX IF EXISTS plugins_slug_trgm');
     }
 };

--- a/database/migrations/2025_02_21_174738_add_trigram_indexes.php
+++ b/database/migrations/2025_02_21_174738_add_trigram_indexes.php
@@ -1,0 +1,24 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    public function up(): void
+    {
+        DB::raw('CREATE EXTENSION IF NOT EXISTS pg_trgm');
+        DB::raw('CREATE INDEX plugins_slug_trgm ON plugins USING GIST (slug gist_trgm_ops(siglen=48))');
+        DB::raw('CREATE INDEX plugins_name_trgm ON plugins USING GIST (name gist_trgm_ops(siglen=48))');
+        DB::raw(
+            'CREATE INDEX plugins_short_description_trgm ON plugins USING GIST (short_description gist_trgm_ops(siglen=48))',
+        );
+    }
+
+    public function down(): void
+    {
+        DB::raw('DROP INDEX plugins_short_description_trgm');
+        DB::raw('DROP INDEX plugins_name_trgm');
+        DB::raw('DROP INDEX plugins_slug_trgm');
+    }
+};


### PR DESCRIPTION
# Pull Request

## What changed?

* Made use of `pg_trgm` similarity searching on several of the plugin and theme columns.
* Use UNION ALL query to build search results in order of specificity (slugs, name, short description, then description).

## Why did it change?

Our search functionality doesn't have to be as good as .org, but this gets us to acceptable.

## Did you fix any specific issues?

None (the search performance issue was closed previously, this is about making it smarter)

## CERTIFICATION

By opening this pull request, I do agree to abide by the [Code of Conduct](https://github.com/aspirepress/.github/blob/updating-contributor-policy/CODE_OF_CONDUCT.md) and be bound by the terms of the [Contribution Guidelines](https://github.com/aspirepress/.github/blob/updating-contributor-policy/CONTRIBUTING.md) in effect on the date and time of my contribution as proven by the revision information in GitHub.

