### PR TITLE
Implement /core/serve-happy

### DIFF
--- a/app/Http/Controllers/API/WpOrg/Core/ServeHappyController.php
+++ b/app/Http/Controllers/API/WpOrg/Core/ServeHappyController.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers\API\WpOrg\Core;
+
+use App\Http\Controllers\Controller;
+use Illuminate\Http\Request;
+
+class ServeHappyController extends Controller
+{
+    // "Recommended" according to an ancient wp.org api anyway.  Not useful for anything but mimicking said api.
+    private const string RECOMMENDED_PHP = '7.4';
+    private const string MINIMUM_PHP = '7.2.24';
+    private const string SUPPORTED_PHP = '7.4';
+    private const string SECURE_PHP = '7.4';
+    private const string ACCEPTABLE_PHP = '7.4';
+
+    public function __invoke(Request $request)
+    {
+        $params = $request->validate(['php_version' => 'required|string']);
+        $php_version = $params['php_version'];
+
+        // wp.org also supports jsonp.  we do not and never will.
+        return [
+            'recommended_version' => self::RECOMMENDED_PHP,
+            'minimum_version' => self::MINIMUM_PHP,
+            'is_supported' => version_compare($php_version, self::SUPPORTED_PHP, '>='),
+            'is_secure' => version_compare($php_version, self::SECURE_PHP, '>='),
+            'is_acceptable' => version_compare($php_version, self::ACCEPTABLE_PHP, '>='),
+        ];
+    }
+}

--- a/app/Http/Controllers/API/WpOrg/Core/ServeHappyController.php
+++ b/app/Http/Controllers/API/WpOrg/Core/ServeHappyController.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Http\Controllers\API\WpOrg\Core;
 
 use App\Http\Controllers\Controller;
+use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 
 class ServeHappyController extends Controller
@@ -16,18 +17,18 @@ class ServeHappyController extends Controller
     private const string SECURE_PHP = '7.4';
     private const string ACCEPTABLE_PHP = '7.4';
 
-    public function __invoke(Request $request)
+    public function __invoke(Request $request): JsonResponse
     {
         $params = $request->validate(['php_version' => 'required|string']);
         $php_version = $params['php_version'];
 
         // wp.org also supports jsonp.  we do not and never will.
-        return [
+        return new JsonResponse([
             'recommended_version' => self::RECOMMENDED_PHP,
             'minimum_version' => self::MINIMUM_PHP,
             'is_supported' => version_compare($php_version, self::SUPPORTED_PHP, '>='),
             'is_secure' => version_compare($php_version, self::SECURE_PHP, '>='),
             'is_acceptable' => version_compare($php_version, self::ACCEPTABLE_PHP, '>='),
-        ];
+        ]);
     }
 }

--- a/routes/api.php
+++ b/routes/api.php
@@ -3,6 +3,7 @@
 // Note: api routes are not prefixed, i.e. all routes in here are from the root like web routes
 
 use App\Http\Controllers\API\WpOrg\Core\ImportersController;
+use App\Http\Controllers\API\WpOrg\Core\ServeHappyController;
 use App\Http\Controllers\API\WpOrg\Plugins\PluginInformation_1_2_Controller;
 use App\Http\Controllers\API\WpOrg\Plugins\PluginUpdateCheck_1_1_Controller;
 use App\Http\Controllers\API\WpOrg\SecretKey\SecretKeyController;
@@ -39,7 +40,7 @@ Route::prefix('/')
 
         $router->get('/core/importers/{version}', ImportersController::class)->where(['version' => '1.[01]']);
 
-        $router->any('/core/serve-happy/{version}', CatchAllController::class)->where(['version' => '1.0']);
+        $router->any('/core/serve-happy/{version}', ServeHappyController::class)->where(['version' => '1.0']);
         $router->any('/core/stable-check/{version}', CatchAllController::class)->where(['version' => '1.0']);
         $router->any('/core/version-check/{version}', CatchAllController::class)->where(['version' => '1.[67]']);
 

--- a/tests/Feature/API/WpOrg/ServeHappyControllerTest.php
+++ b/tests/Feature/API/WpOrg/ServeHappyControllerTest.php
@@ -1,0 +1,38 @@
+<?php
+
+it('serves happy', function () {
+    $response = makeApiRequest('GET', '/core/serve-happy/1.0?php_version=8.3');
+
+    $response
+        ->assertStatus(200)
+        ->assertJson([
+            "recommended_version" => "7.4",
+            "minimum_version" => "7.2.24",
+            "is_supported" => true,
+            "is_secure" => true,
+            "is_acceptable" => true,
+        ]);
+});
+
+it('shows false for insecure versions', function () {
+    $response = makeApiRequest('GET', '/core/serve-happy/1.0?php_version=5.3');
+
+    $response
+        ->assertStatus(200)
+        ->assertJson([
+            "recommended_version" => "7.4",
+            "minimum_version" => "7.2.24",
+            "is_supported" => false,
+            "is_secure" => false,
+            "is_acceptable" => false,
+        ]);
+});
+
+it('requires php_version param', function () {
+    // upstream throws 400 and returns a json error, but wp only checks for a 200 status, so these are fine
+    $response = makeApiRequest('GET', '/core/serve-happy/1.0');
+    $response->assertStatus(302); // laravel's validation failure behavior for non-json requests
+
+    $response = makeApiRequest('GET', '/core/serve-happy/1.0', [], ['Accept' => 'application/json']);
+    $response->assertStatus(422);
+});


### PR DESCRIPTION
# Pull Request

## What changed?

Implements the /core/serve-happy endpoint.

## Why did it change?

Because it's trivial so why not? 

## Did you fix any specific issues?

Closes: #46 

## CERTIFICATION

By opening this pull request, I do agree to abide by the [Code of Conduct](https://github.com/aspirepress/.github/blob/updating-contributor-policy/CODE_OF_CONDUCT.md) and be bound by the terms of the [Contribution Guidelines](https://github.com/aspirepress/.github/blob/updating-contributor-policy/CONTRIBUTING.md) in effect on the date and time of my contribution as proven by the revision information in GitHub.

