### PR TITLE
Implement /core/browse-happy

### DIFF
--- a/app/Http/Controllers/API/WpOrg/Core/BrowseHappyController.php
+++ b/app/Http/Controllers/API/WpOrg/Core/BrowseHappyController.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+// As far as I can tell, /core/browse-happy is a telemetry endpoint returning nothing that browsers hit directly.
+// Implementing it here checks off an item on the compatibility list, but it'll likely never see use in the real world.
+
+namespace App\Http\Controllers\API\WpOrg\Core;
+
+use App\Http\Controllers\Controller;
+use Illuminate\Http\Request;
+
+class BrowseHappyController extends Controller
+{
+    public function __invoke(Request $request): string
+    {
+        return '';
+    }
+}

--- a/app/Http/Controllers/PassThroughController.php
+++ b/app/Http/Controllers/PassThroughController.php
@@ -13,7 +13,7 @@ use Illuminate\Support\Str;
 
 use function Safe\json_encode;
 
-class CatchAllController extends Controller
+class PassThroughController extends Controller
 {
     public function __invoke(Request $request): Response
     {

--- a/routes/api.php
+++ b/routes/api.php
@@ -10,7 +10,7 @@ use App\Http\Controllers\API\WpOrg\Plugins\PluginUpdateCheck_1_1_Controller;
 use App\Http\Controllers\API\WpOrg\SecretKey\SecretKeyController;
 use App\Http\Controllers\API\WpOrg\Themes\ThemeController;
 use App\Http\Controllers\API\WpOrg\Themes\ThemeUpdatesController;
-use App\Http\Controllers\CatchAllController;
+use App\Http\Controllers\PassThroughController;
 use App\Http\Middleware\NormalizeWpOrgRequest;
 use Illuminate\Routing\Router;
 use Illuminate\Support\Facades\Route;
@@ -39,32 +39,32 @@ Route::prefix('/')
         $router->get('/themes/info/{version}', [ThemeController::class, 'info'])->where(['version' => '1.[012]']);
         $router->match(['get', 'post'], '/themes/update-check/{version}', ThemeUpdatesController::class)->where(['version' => '1.[01]']);
 
-        // CatchAll passes the request through to .org (and probably should be renamed)
+        /// Pass-through routes still going to .org
 
-        $router->any('/core/checksums/{version}', CatchAllController::class)->where(['version' => '1.0']);
-        $router->any('/core/credits/{version}', CatchAllController::class)->where(['version' => '1.[01]']);
-        $router->any('/core/handbook/{version}', CatchAllController::class)->where(['version' => '1.0']);
-        $router->any('/core/stable-check/{version}', CatchAllController::class)->where(['version' => '1.0']);
-        $router->any('/core/version-check/{version}', CatchAllController::class)->where(['version' => '1.[67]']);
+        $router->any('/core/checksums/{version}', PassThroughController::class)->where(['version' => '1.0']);
+        $router->any('/core/credits/{version}', PassThroughController::class)->where(['version' => '1.[01]']);
+        $router->any('/core/handbook/{version}', PassThroughController::class)->where(['version' => '1.0']);
+        $router->any('/core/stable-check/{version}', PassThroughController::class)->where(['version' => '1.0']);
+        $router->any('/core/version-check/{version}', PassThroughController::class)->where(['version' => '1.[67]']);
 
-        $router->any('/events/{version}', CatchAllController::class)->where(['version' => '1.0']);
+        $router->any('/events/{version}', PassThroughController::class)->where(['version' => '1.0']);
 
-        $router->any('/patterns/{version}', CatchAllController::class)->where(['version' => '1.0']);
+        $router->any('/patterns/{version}', PassThroughController::class)->where(['version' => '1.0']);
 
         // /plugins endpoints are implemented for version 1.2, older versions are still pass-through
-        $router->any('/plugins/info/{version}', CatchAllController::class)->where(['version' => '1.[01]']);
-        $router->any('/plugins/update-check/{version}', CatchAllController::class)->where(['version' => '1.0']);
+        $router->any('/plugins/info/{version}', PassThroughController::class)->where(['version' => '1.[01]']);
+        $router->any('/plugins/update-check/{version}', PassThroughController::class)->where(['version' => '1.0']);
 
-        $router->any('/stats/locale/{version}', CatchAllController::class)->where(['version' => '1.0']);
-        $router->any('/stats/mysql/{version}', CatchAllController::class)->where(['version' => '1.0']);
-        $router->any('/stats/php/{version}', CatchAllController::class)->where(['version' => '1.0']);
-        $router->any('/stats/plugin/{version}/downloads.php', CatchAllController::class)->where(['version' => '1.0']);
-        $router->any('/stats/plugin/{version}/{slug}', CatchAllController::class)->where(['version' => '1.0']);
-        $router->any('/stats/wordpress/{version}', CatchAllController::class)->where(['version' => '1.0']);
+        $router->any('/stats/locale/{version}', PassThroughController::class)->where(['version' => '1.0']);
+        $router->any('/stats/mysql/{version}', PassThroughController::class)->where(['version' => '1.0']);
+        $router->any('/stats/php/{version}', PassThroughController::class)->where(['version' => '1.0']);
+        $router->any('/stats/plugin/{version}/downloads.php', PassThroughController::class)->where(['version' => '1.0']);
+        $router->any('/stats/plugin/{version}/{slug}', PassThroughController::class)->where(['version' => '1.0']);
+        $router->any('/stats/wordpress/{version}', PassThroughController::class)->where(['version' => '1.0']);
 
-        $router->any('/translations/core/{version}', CatchAllController::class)->where(['version' => '1.0']);
-        $router->any('/translations/plugins/{version}', CatchAllController::class)->where(['version' => '1.0']);
-        $router->any('/translations/themes/{version}', CatchAllController::class)->where(['version' => '1.0']);
+        $router->any('/translations/core/{version}', PassThroughController::class)->where(['version' => '1.0']);
+        $router->any('/translations/plugins/{version}', PassThroughController::class)->where(['version' => '1.0']);
+        $router->any('/translations/themes/{version}', PassThroughController::class)->where(['version' => '1.0']);
 
         // @formatter:on
     });

--- a/routes/api.php
+++ b/routes/api.php
@@ -2,6 +2,7 @@
 
 // Note: api routes are not prefixed, i.e. all routes in here are from the root like web routes
 
+use App\Http\Controllers\API\WpOrg\Core\BrowseHappyController;
 use App\Http\Controllers\API\WpOrg\Core\ImportersController;
 use App\Http\Controllers\API\WpOrg\Core\ServeHappyController;
 use App\Http\Controllers\API\WpOrg\Plugins\PluginInformation_1_2_Controller;
@@ -33,7 +34,7 @@ Route::prefix('/')
         $router->any('/stats/plugin/{version}/downloads.php', CatchAllController::class)->where(['version' => '1.0']);
         $router->any('/stats/plugin/{version}/{slug}', CatchAllController::class)->where(['version' => '1.0']);
 
-        $router->any('/core/browse-happy/{version}', CatchAllController::class)->where(['version' => '1.1']);
+        $router->any('/core/browse-happy/{version}', BrowseHappyController::class)->where(['version' => '1.1']);
         $router->any('/core/checksums/{version}', CatchAllController::class)->where(['version' => '1.0']);
         $router->any('/core/credits/{version}', CatchAllController::class)->where(['version' => '1.[01]']);
         $router->any('/core/handbook/{version}', CatchAllController::class)->where(['version' => '1.0']);

--- a/routes/api.php
+++ b/routes/api.php
@@ -24,44 +24,49 @@ Route::prefix('/')
         'cache.headers:public;s_maxage=300,etag', // for the CDN's benefit: the WP user agent does not cache at all.
     ])
     ->group(function (Router $router) {
+        // @formatter:off
+
+        $router->any('/core/browse-happy/{version}', BrowseHappyController::class)->where(['version' => '1.1']);
+        $router->any('/core/serve-happy/{version}', ServeHappyController::class)->where(['version' => '1.0']);
+        $router->get('/core/importers/{version}', ImportersController::class)->where(['version' => '1.[01]']);
+
+        $router->get('/plugins/info/1.2', PluginInformation_1_2_Controller::class);
+        $router->post('/plugins/update-check/1.1', PluginUpdateCheck_1_1_Controller::class);
+
         $router->get('/secret-key/{version}', [SecretKeyController::class, 'index'])->where(['version' => '1.[01]']);
         $router->get('/secret-key/{version}/salt', [SecretKeyController::class, 'salt'])->where(['version' => '1.1']);
 
-        $router->any('/stats/wordpress/{version}', CatchAllController::class)->where(['version' => '1.0']);
-        $router->any('/stats/php/{version}', CatchAllController::class)->where(['version' => '1.0']);
-        $router->any('/stats/mysql/{version}', CatchAllController::class)->where(['version' => '1.0']);
-        $router->any('/stats/locale/{version}', CatchAllController::class)->where(['version' => '1.0']);
-        $router->any('/stats/plugin/{version}/downloads.php', CatchAllController::class)->where(['version' => '1.0']);
-        $router->any('/stats/plugin/{version}/{slug}', CatchAllController::class)->where(['version' => '1.0']);
+        $router->get('/themes/info/{version}', [ThemeController::class, 'info'])->where(['version' => '1.[012]']);
+        $router->match(['get', 'post'], '/themes/update-check/{version}', ThemeUpdatesController::class)->where(['version' => '1.[01]']);
 
-        $router->any('/core/browse-happy/{version}', BrowseHappyController::class)->where(['version' => '1.1']);
+        // CatchAll passes the request through to .org (and probably should be renamed)
+
         $router->any('/core/checksums/{version}', CatchAllController::class)->where(['version' => '1.0']);
         $router->any('/core/credits/{version}', CatchAllController::class)->where(['version' => '1.[01]']);
         $router->any('/core/handbook/{version}', CatchAllController::class)->where(['version' => '1.0']);
-
-        $router->get('/core/importers/{version}', ImportersController::class)->where(['version' => '1.[01]']);
-
-        $router->any('/core/serve-happy/{version}', ServeHappyController::class)->where(['version' => '1.0']);
         $router->any('/core/stable-check/{version}', CatchAllController::class)->where(['version' => '1.0']);
         $router->any('/core/version-check/{version}', CatchAllController::class)->where(['version' => '1.[67]']);
+
+        $router->any('/events/{version}', CatchAllController::class)->where(['version' => '1.0']);
+
+        $router->any('/patterns/{version}', CatchAllController::class)->where(['version' => '1.0']);
+
+        // /plugins endpoints are implemented for version 1.2, older versions are still pass-through
+        $router->any('/plugins/info/{version}', CatchAllController::class)->where(['version' => '1.[01]']);
+        $router->any('/plugins/update-check/{version}', CatchAllController::class)->where(['version' => '1.0']);
+
+        $router->any('/stats/locale/{version}', CatchAllController::class)->where(['version' => '1.0']);
+        $router->any('/stats/mysql/{version}', CatchAllController::class)->where(['version' => '1.0']);
+        $router->any('/stats/php/{version}', CatchAllController::class)->where(['version' => '1.0']);
+        $router->any('/stats/plugin/{version}/downloads.php', CatchAllController::class)->where(['version' => '1.0']);
+        $router->any('/stats/plugin/{version}/{slug}', CatchAllController::class)->where(['version' => '1.0']);
+        $router->any('/stats/wordpress/{version}', CatchAllController::class)->where(['version' => '1.0']);
 
         $router->any('/translations/core/{version}', CatchAllController::class)->where(['version' => '1.0']);
         $router->any('/translations/plugins/{version}', CatchAllController::class)->where(['version' => '1.0']);
         $router->any('/translations/themes/{version}', CatchAllController::class)->where(['version' => '1.0']);
 
-        $router->get('/themes/info/{version}', [ThemeController::class, 'info'])->where(['version' => '1.[012]']);
-        $router->match(['get', 'post'], '/themes/update-check/{version}', ThemeUpdatesController::class)->where(
-            ['version' => '1.[01]'],
-        );
-
-        $router->get('/plugins/info/1.2', PluginInformation_1_2_Controller::class);
-        $router->any('/plugins/info/{version}', CatchAllController::class)->where(['version' => '1.[01]']);
-
-        $router->post('/plugins/update-check/1.1', PluginUpdateCheck_1_1_Controller::class);
-        $router->any('/plugins/update-check/{version}', CatchAllController::class)->where(['version' => '1.0']);
-
-        $router->any('/patterns/{version}', CatchAllController::class)->where(['version' => '1.0']);
-        $router->any('/events/{version}', CatchAllController::class)->where(['version' => '1.0']);
+        // @formatter:on
     });
 
 // Route::any('{path}', CatchAllController::class)->where('path', '.*');

--- a/tests/Feature/API/WpOrg/BrowseHappyControllerTest.php
+++ b/tests/Feature/API/WpOrg/BrowseHappyControllerTest.php
@@ -1,0 +1,6 @@
+<?php
+
+it('browses happy', function () {
+    $response = makeApiRequest('GET', '/core/browse-happy/1.1');
+    $response->assertStatus(200);
+});


### PR DESCRIPTION
# Pull Request

## What changed?

* Added /core/browse-happy/1.1 that does nothing but return a blank page.
* Renamed CatchAllController to PassThroughController to make it more obvious what it does.

## Why did it change?

Possibly the endpoint does more on a POST, but I think all it does is collect telemetry.  I'm also pretty sure this endpoint is only hit by browsers, meaning AU won't rewrite it anyway.  It's not impossible to intercept browser requests, but the juice isn't worth the squeeze, especially not for this endpoint.  

## Did you fix any specific issues?

Closes: #45 

## CERTIFICATION

By opening this pull request, I do agree to abide by the [Code of Conduct](https://github.com/aspirepress/.github/blob/updating-contributor-policy/CODE_OF_CONDUCT.md) and be bound by the terms of the [Contribution Guidelines](https://github.com/aspirepress/.github/blob/updating-contributor-policy/CONTRIBUTING.md) in effect on the date and time of my contribution as proven by the revision information in GitHub.

