### PR TITLE
fix: make 'popular' categories use active_installs desc for order

### DIFF
--- a/app/Services/Plugins/QueryPluginsService.php
+++ b/app/Services/Plugins/QueryPluginsService.php
@@ -97,12 +97,12 @@ class QueryPluginsService
      */
     private static function applyBrowse(Builder $query, string $browse): void
     {
-        // TODO: replicate 'featured' browse (currently it's identical to 'popular')
+        // TODO: replicate 'featured' browse (currently it's identical to 'top-rated')
         match ($browse) {
             'new' => $query->reorder('added', 'desc'),
             'updated' => $query->reorder('last_updated', 'desc'),
-            'top-rated', 'popular', 'featured' => $query->reorder('rating', 'desc'),
-            default => $query->reorder('active_installs', 'desc'),
+            'top-rated', 'featured' => $query->reorder('rating', 'desc'),
+            default => $query->reorder('active_installs', 'desc'),  // 'popular' is also the default
         };
     }
 

--- a/app/Services/Themes/QueryThemesService.php
+++ b/app/Services/Themes/QueryThemesService.php
@@ -48,9 +48,9 @@ class QueryThemesService
     {
         // TODO: replicate 'featured' browse (currently it's identical to 'popular')
         match ($browse) {
-            'popular', 'featured' => $query->reorder('rating', 'desc'),
+            'featured' => $query->reorder('rating', 'desc'),
             'new' => $query->reorder('creation_time', 'desc'),
-            default => null,
+            default => $query->reorder('active_installs', 'desc'), // 'popular' is also the default
         };
     }
 


### PR DESCRIPTION
# Pull Request

## What changed?

* Fixes both plugins and themes queries to sort by installs for the 'popular' category, and to make that the default/fallback browse sort as well for both (was already the case for plugins)

## Why did it change?

Fixes search results.

## Did you fix any specific issues?

none.  h/t to @afragen for spotting the issue.

## CERTIFICATION

By opening this pull request, I do agree to abide by the [Code of Conduct](https://github.com/aspirepress/.github/blob/updating-contributor-policy/CODE_OF_CONDUCT.md) and be bound by the terms of the [Contribution Guidelines](https://github.com/aspirepress/.github/blob/updating-contributor-policy/CONTRIBUTING.md) in effect on the date and time of my contribution as proven by the revision information in GitHub.

