### PR TITLE
Security hardening, upgrade php to 8.4

### DIFF
--- a/.github/workflows/run-checks.yaml
+++ b/.github/workflows/run-checks.yaml
@@ -24,7 +24,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@9e72090525849c5e82e596468b86eb55e9cc5401 # v2
         with:
-          php-version: '8.3'
+          php-version: '8.4'
 
       - name: Install Composer dependencies
         run: composer install

--- a/.github/workflows/run-checks.yaml
+++ b/.github/workflows/run-checks.yaml
@@ -6,15 +6,23 @@ on:
   pull_request:
     branches: [ main ]
 
+permissions: # added using https://github.com/step-security/secure-repo
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - name: Harden the runner (Audit all outbound calls)
+        uses: step-security/harden-runner@4d991eb9b905ef189e4c376166672c3f2f230481 # v2.11.0
+        with:
+          egress-policy: audit
+
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Setup PHP
-        uses: shivammathur/setup-php@v2
+        uses: shivammathur/setup-php@9e72090525849c5e82e596468b86eb55e9cc5401 # v2
         with:
           php-version: '8.3'
 

--- a/docker-compose.override.yml.dist
+++ b/docker-compose.override.yml.dist
@@ -2,17 +2,18 @@
 # This is an example file only, and is NOT loaded by default.
 
 services:
-  webapp:
-    environment:
-        - XDEBUG_CONFIG=idekey=PHPSTORM start_with_request=true var_display_max_depth=-1 max_nesting_level=3000 client_host=172.17.0.1
-        - PHP_IDE_CONFIG=serverName=application.local
-        - XDEBUG_MODE=develop,debug,coverage
+    webapp:
+        ports:
+            - ${LOCAL_HTTP_PORT:-8099}:80
+        environment:
+            - XDEBUG_CONFIG=idekey=PHPSTORM start_with_request=true var_display_max_depth=-1 max_nesting_level=3000 client_host=172.17.0.1
+            - PHP_IDE_CONFIG=serverName=application.local
+            - XDEBUG_MODE=develop,debug,coverage
 
-    ports: !reset []
+    postgres:
+        ports:
+            - "${LOCAL_POSTGRES_PORT:-5432}:5432"
 
-  nginx:
-    ports: !reset []
-
-  postgres:
-    ports: !reset []
-
+    mailpit:
+        ports:
+            - "${LOCAL_MAILPIT_PORT:-8025}:8025"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,8 +4,6 @@ services:
             context: .
             dockerfile: docker/webapp/Dockerfile
             target: dev
-        ports:
-            - ${LOCAL_HTTP_PORT:-8099}:80
         volumes:
             - .:/app
             - ./docker/webapp/Caddyfile:/etc/caddy/Caddyfile
@@ -33,8 +31,6 @@ services:
             - POSTGRES_PASSWORD=password
             - PGDATA=/opt/pgdata
             - POSTGRES_DB=aspirecloud
-        ports:
-            - "${LOCAL_POSTGRES_PORT:-5432}:5432"
         volumes:
             - postgresdata:/opt/pgdata
         networks:
@@ -70,8 +66,6 @@ services:
     mailpit:
         image: axllent/mailpit:v1.21.4
         restart: unless-stopped
-        ports:
-            - "${LOCAL_MAILPIT_PORT:-8025}:8025"
         networks:
             app-net: ~
             aspire-net:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,6 +8,8 @@ services:
             - ${LOCAL_HTTP_PORT:-8099}:80
         volumes:
             - .:/app
+            - ./docker/webapp/Caddyfile:/etc/caddy/Caddyfile
+            - ./docker/webapp/php.ini:/usr/local/etc/php/php.ini
         networks:
             traefik: ~
             app-net: ~

--- a/docker/cli/Dockerfile
+++ b/docker/cli/Dockerfile
@@ -9,7 +9,7 @@ RUN install-php-extensions pdo pdo_pgsql zip intl redis
 
 COPY ./docker/cli/php.ini /usr/local/etc/php/php.ini
 
-RUN useradd --create-home --shell /bin/bash app
+RUN useradd --uid 100000 --create-home --shell /bin/bash app
 
 WORKDIR /app
 

--- a/docker/cli/Dockerfile
+++ b/docker/cli/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:8.4-cli AS base
+FROM php:8.4.4-cli-bookworm AS base
 
 COPY --from=composer:2.8.5 /usr/bin/composer /usr/bin/composer
 ADD --chmod=0755 https://github.com/mlocati/docker-php-extension-installer/releases/download/2.7.14/install-php-extensions /usr/local/bin/

--- a/docker/laravel-worker/Dockerfile
+++ b/docker/laravel-worker/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:8.3-cli AS base
+FROM php:8.4.4-cli-bookworm AS base
 
 COPY --from=composer:2.8.5 /usr/bin/composer /usr/bin/composer
 ADD --chmod=0755 https://github.com/mlocati/docker-php-extension-installer/releases/download/2.7.14/install-php-extensions /usr/local/bin/

--- a/docker/laravel-worker/Dockerfile
+++ b/docker/laravel-worker/Dockerfile
@@ -9,7 +9,7 @@ RUN install-php-extensions pdo pdo_pgsql zip intl opcache redis
 
 COPY ./docker/cli/php.ini /usr/local/etc/php/php.ini
 
-RUN useradd --create-home --shell /bin/bash app
+RUN useradd --uid 100000 --create-home --shell /bin/bash app
 
 WORKDIR /app
 

--- a/docker/webapp/Caddyfile
+++ b/docker/webapp/Caddyfile
@@ -10,4 +10,5 @@ http:// {
     root * /app/public
     php_server
     log
+    encode zstd gzip
 }

--- a/docker/webapp/Dockerfile
+++ b/docker/webapp/Dockerfile
@@ -1,4 +1,4 @@
-FROM dunglas/frankenphp:1.4.1-php8.4.3-bookworm AS base
+FROM dunglas/frankenphp:1.4.4-php8.4.4-bookworm AS base
 
 COPY --from=composer:2.8.5 /usr/bin/composer /usr/bin/composer
 ADD --chmod=0755 https://github.com/mlocati/docker-php-extension-installer/releases/download/2.7.14/install-php-extensions /usr/local/bin/

--- a/docker/webapp/Dockerfile
+++ b/docker/webapp/Dockerfile
@@ -15,7 +15,7 @@ COPY ./docker/webapp/php.ini /usr/local/etc/php/php.ini
 
 # frankenphp sets XDG_CONFIG_HOME=/config and XDG_DATA_HOME=/data, and I won't change these in case they're hardwired
 
-RUN useradd --create-home --shell /bin/bash app \
+RUN useradd --uid 100000 --create-home --shell /bin/bash app \
     && chown -R app:app /config /data \
     && apt update \
     && apt install -y nodejs npm postgresql-client


### PR DESCRIPTION
# Pull Request

## What changed?

* PHP version in runners and containers upgraded to 8.4
* Container app user now runs as a high UID (100000) instead of the usual 1000 so as not to collide with any existing users.
* CI runner is hardened to use read-only permissions, pinned version hashes, and egress auditing.

## Why did it change?

In the wake of the [tj-actions supply chain attack](https://semgrep.dev/blog/2025/popular-github-action-tj-actionschanged-files-is-compromised/) we need to have tighter controls on runner actions, especially third-party ones.

## Did you fix any specific issues?

none

## CERTIFICATION

By opening this pull request, I do agree to abide by the [Code of Conduct](https://github.com/aspirepress/.github/blob/updating-contributor-policy/CODE_OF_CONDUCT.md) and be bound by the terms of the [Contribution Guidelines](https://github.com/aspirepress/.github/blob/updating-contributor-policy/CONTRIBUTING.md) in effect on the date and time of my contribution as proven by the revision information in GitHub.

