### PR TITLE
update dependabot.yml to include composer, only lockfile changes

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,5 +1,17 @@
 version: 2
 updates:
+  - package-ecosystem: npm
+    versioning-strategy: lockfile-only
+    directory: /
+    schedule:
+      interval: daily
+
+  - package-ecosystem: composer
+    versioning-strategy: lockfile-only
+    directory: /
+    schedule:
+      interval: daily
+
   - package-ecosystem: docker
     directory: /docker/cli
     schedule:
@@ -12,10 +24,5 @@ updates:
 
   - package-ecosystem: docker
     directory: /docker/webapp
-    schedule:
-      interval: daily
-
-  - package-ecosystem: npm
-    directory: /
     schedule:
       interval: daily


### PR DESCRIPTION
# Pull Request

## What changed?

* Added the `composer` ecosystem to dependabot.
* For both `composer` and npm, only suggest lockfile upgrades.  Version ranges exist for a reason.

## Why did it change?

Need PHP upgrades, but also don't need dependabot trying to put everything on bleeding edge versions in an automated fashion.

## Did you fix any specific issues?

none

## CERTIFICATION

By opening this pull request, I do agree to abide by the [Code of Conduct](https://github.com/aspirepress/.github/blob/updating-contributor-policy/CODE_OF_CONDUCT.md) and be bound by the terms of the [Contribution Guidelines](https://github.com/aspirepress/.github/blob/updating-contributor-policy/CONTRIBUTING.md) in effect on the date and time of my contribution as proven by the revision information in GitHub.

