### PR TITLE
hack: silence type errors around BelongsToMany

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -50,6 +50,8 @@
         }
     },
     "scripts": {
+        "phpstan": "phpstan --memory-limit=2G --verbose",
+        "pint": "pint",
         "post-autoload-dump": [
             "Illuminate\\Foundation\\ComposerScripts::postAutoloadDump",
             "@php artisan package:discover --ansi"

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -17,5 +17,5 @@ parameters:
         # Can occasionally catch a mistake, but usually just forbids using assert() in places that actually need it
         - '#will always evaluate to true#'
 
-
-
+        # BelongsToMany is totally broken with larastan now, but things are even more broken without it.
+        - "#should return.*BelongsToMany<#"


### PR DESCRIPTION
# Pull Request

## What changed?

Suppresses phpstan type errors around the return type of any method returning BelongsToMany.  Also added phpstan and pint to the composer scripts for convenience.

## Why did it change?

Laravel's source says BelongsToMany takes three type args, but phpstan insists it only takes two in docblock annotations, but then suddenly agrees with Laravel when it reaches the actual return point, and infers three type args from the return value.   Could be a Larastan issue, but if I disable Larastan, it fails typechecks all the live long day because Laravel is what it is.  At any rate, nothing can satisfy phpstan when it can't even agree with itself, so it goes in the ignore list.

## Did you fix any specific issues?

none

## CERTIFICATION

By opening this pull request, I do agree to abide by the [Code of Conduct](https://github.com/aspirepress/.github/blob/updating-contributor-policy/CODE_OF_CONDUCT.md) and be bound by the terms of the [Contribution Guidelines](https://github.com/aspirepress/.github/blob/updating-contributor-policy/CONTRIBUTING.md) in effect on the date and time of my contribution as proven by the revision information in GitHub.

