### PR TITLE
meta: use weekly batched dependabot updates for npm and composer

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,16 +1,30 @@
 version: 2
 updates:
+  # limit routine package updates to the declared constraints, and group them all into a single weekly PR
+
   - package-ecosystem: npm
     versioning-strategy: lockfile-only
     directory: /
     schedule:
-      interval: daily
+      interval: weekly
+    groups:
+      default-group:
+        applies-to: version-updates
+        patterns:
+          - '*'
 
   - package-ecosystem: composer
     versioning-strategy: lockfile-only
     directory: /
     schedule:
-      interval: daily
+      interval: weekly
+    groups:
+      default-group:
+        applies-to: version-updates
+        patterns:
+          - '*'
+
+  # Package ecosystems below have lower traffic and we don't benefit much from weekly batches
 
   - package-ecosystem: docker
     directory: /docker/cli


### PR DESCRIPTION
# Pull Request

## What changed?

Switches dependabot to create PRs in batches for npm and composer packages.  docker and github actions tend to be low-noise in terms of updates, so they continue to be on a daily schedule.

## Why did it change?

Too much PR spam.

## Did you fix any specific issues?

none.

## CERTIFICATION

By opening this pull request, I do agree to abide by the [Code of Conduct](https://github.com/aspirepress/.github/blob/updating-contributor-policy/CODE_OF_CONDUCT.md) and be bound by the terms of the [Contribution Guidelines](https://github.com/aspirepress/.github/blob/updating-contributor-policy/CONTRIBUTING.md) in effect on the date and time of my contribution as proven by the revision information in GitHub.

