### PR TITLE
fix: use correct type for $requires in ThemeResponse

### DIFF
--- a/app/Values/WpOrg/Themes/ThemeResponse.php
+++ b/app/Values/WpOrg/Themes/ThemeResponse.php
@@ -19,7 +19,6 @@ readonly class ThemeResponse extends Bag
      * @param Optional|array<string, mixed> $sections
      * @param Optional|array<string, mixed> $tags
      * @param Optional|array<string, mixed> $versions
-     * @param Optional|array<string, mixed> $requires
      * @param Optional|array<string, mixed> $screenshots
      * @param Optional|array<string, mixed> $photon_screenshots
      * @param Optional|array<string, mixed> $trac_tickets
@@ -46,7 +45,7 @@ readonly class ThemeResponse extends Bag
         public Optional|string $download_link,
         public Optional|array $tags,
         public Optional|array $versions,
-        public Optional|array $requires,
+        public Optional|string $requires,
         public Optional|string $requires_php,
         public Optional|bool $is_commercial,
         public Optional|string $external_support_url,


### PR DESCRIPTION
# Pull Request

## What changed?

Fixes the type of one of ThemeResponse fields to avoid a string to array conversion error.

## Why did it change?

bugfix

## Did you fix any specific issues?

none

## CERTIFICATION

By opening this pull request, I do agree to abide by the [Code of Conduct](https://github.com/aspirepress/.github/blob/updating-contributor-policy/CODE_OF_CONDUCT.md) and be bound by the terms of the [Contribution Guidelines](https://github.com/aspirepress/.github/blob/updating-contributor-policy/CONTRIBUTING.md) in effect on the date and time of my contribution as proven by the revision information in GitHub.

