### PR TITLE
security: use uid/gid of 100000 in app containers

### DIFF
--- a/docker/cli/Dockerfile
+++ b/docker/cli/Dockerfile
@@ -15,7 +15,8 @@ RUN curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg -
     && apt install -y nodejs \
     && npm install -g yarn
 
-RUN useradd --uid 100000 --create-home --shell /bin/bash app
+RUN groupadd --gid 100000 app \
+    && useradd --uid 100000 --gid 100000 --create-home --shell /bin/bash app
 
 WORKDIR /app
 

--- a/docker/laravel-worker/Dockerfile
+++ b/docker/laravel-worker/Dockerfile
@@ -9,7 +9,8 @@ RUN install-php-extensions pdo pdo_pgsql zip intl opcache redis
 
 COPY ./docker/cli/php.ini /usr/local/etc/php/php.ini
 
-RUN useradd --uid 100000 --create-home --shell /bin/bash app
+RUN groupadd --gid 100000 app \
+    && useradd --uid 100000 --gid 100000 --create-home --shell /bin/bash app
 
 WORKDIR /app
 

--- a/docker/webapp/Dockerfile
+++ b/docker/webapp/Dockerfile
@@ -15,7 +15,10 @@ RUN curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg -
     && apt update && apt install -y nodejs \
     && npm install -g yarn
 
-RUN useradd --uid 100000 --create-home --shell /bin/bash app && chown -R app:app /config /data
+
+RUN groupadd --gid 100000 app \
+    && useradd --uid 100000 --gid 100000 --create-home --shell /bin/bash app \
+    && chown -R app:app /config /data
 
 WORKDIR /app
 
@@ -24,7 +27,7 @@ FROM base AS dev
 
 RUN install-php-extensions xdebug
 
-#USER app
+USER app
 
 ################
 FROM base AS prod


### PR DESCRIPTION
# Pull Request

## What changed?

* Changes the uid and gid of the `app` user from 1000 to 100000 to make it unlikely it will overlap with existing users on the host.

## Why did it change?

This makes it such that a container breakout in kubernetes will not run with any existing user's permissions, which limits the immediate blast radius.  Also, since `ps` always displays usernames from the global namespace, it makes the output less confusing -- you'll know processes with a high numeric uid are a container.

It has no real effect in dev environments, local filesystem mapping will still work as normal.

## Did you fix any specific issues?

none

## CERTIFICATION

By opening this pull request, I do agree to abide by the [Code of Conduct](https://github.com/aspirepress/.github/blob/updating-contributor-policy/CODE_OF_CONDUCT.md) and be bound by the terms of the [Contribution Guidelines](https://github.com/aspirepress/.github/blob/updating-contributor-policy/CONTRIBUTING.md) in effect on the date and time of my contribution as proven by the revision information in GitHub.

