### PR TITLE
fix performance issues with hot_tags

### DIFF
--- a/app/Services/Plugins/PluginHotTagsService.php
+++ b/app/Services/Plugins/PluginHotTagsService.php
@@ -15,10 +15,20 @@ class PluginHotTagsService
     public function getHotTags(int $count = -1): array
     {
         $hotTags = PluginTag::query()
-            ->withCount('plugins')
+            ->select('plugin_tags.*')
+            ->join('plugin_plugin_tags', 'plugin_tags.id', '=', 'plugin_plugin_tags.plugin_tag_id')
+            ->selectRaw('COUNT(plugin_plugin_tags.plugin_id) as plugins_count')
+            ->groupBy('plugin_tags.id', 'plugin_tags.name', 'plugin_tags.slug')
             ->orderBy('plugins_count', 'desc')
             ->limit($count >= 0 ? $count : 100)
             ->get();
+
+        // This was the first attempt, and it blows up the database with nested scans.  Do not do this.
+        // $hotTags = PluginTag::query()
+        //     ->withCount('plugins')
+        //     ->orderBy('plugins_count', 'desc')
+        //     ->limit($count >= 0 ? $count : 100)
+        //     ->get();
 
         return PluginHotTagsResponse::collect($hotTags)
             ->mapWithKeys(fn(PluginHotTagsResponse $tag) => [$tag->slug => $tag])

--- a/app/Services/Themes/ThemeHotTagsService.php
+++ b/app/Services/Themes/ThemeHotTagsService.php
@@ -15,10 +15,20 @@ class ThemeHotTagsService
     public function getHotTags(int $count = -1): array
     {
         $hotTags = ThemeTag::query()
-            ->withCount('themes')
+            ->select('theme_tags.*')
+            ->join('theme_theme_tags', 'theme_tags.id', '=', 'theme_theme_tags.theme_tag_id')
+            ->selectRaw('COUNT(theme_theme_tags.theme_id) as themes_count')
+            ->groupBy('theme_tags.id', 'theme_tags.name', 'theme_tags.slug')
             ->orderBy('themes_count', 'desc')
             ->limit($count >= 0 ? $count : 100)
             ->get();
+
+        // this blows up the database.  do not use this.
+        // $hotTags = ThemeTag::query()
+        //     ->withCount('themes')
+        //     ->orderBy('themes_count', 'desc')
+        //     ->limit($count >= 0 ? $count : 100)
+        //     ->get();
 
         return ThemeHotTagsResponse::collect($hotTags)
             ->mapWithKeys(fn(ThemeHotTagsResponse $tag) => [$tag->slug => $tag])


### PR DESCRIPTION
# Pull Request

## What changed?

Use a more low-level means of getting plugin and theme counts for hot_tags query instead of Eloquent's withCount()

## Why did it change?

withCount() completely blows up the DB with nested seq scans, so I expressed the sql we should have written in the first place using the Eloquent builder.  

## Did you fix any specific issues?

none.  h/t to @toderash for spotting the issue

## CERTIFICATION

By opening this pull request, I do agree to abide by the [Code of Conduct](https://github.com/aspirepress/.github/blob/updating-contributor-policy/CODE_OF_CONDUCT.md) and be bound by the terms of the [Contribution Guidelines](https://github.com/aspirepress/.github/blob/updating-contributor-policy/CONTRIBUTING.md) in effect on the date and time of my contribution as proven by the revision information in GitHub.

