### PR TITLE
Partially implement `core/version-check` endpoint.

### DIFF
--- a/app/Http/Controllers/API/WpOrg/Core/VersionCheckController.php
+++ b/app/Http/Controllers/API/WpOrg/Core/VersionCheckController.php
@@ -1,0 +1,245 @@
+<?php
+
+namespace App\Http\Controllers\API\WpOrg\Core;
+
+use Illuminate\Http\Request;
+use Illuminate\Http\JsonResponse;
+use App\Http\Controllers\Controller;
+
+class VersionCheckController extends Controller
+{
+    /**
+     * The currently installed version of WordPress.
+     *
+     * @var string
+     */
+    private string $currentVersion;
+
+    /**
+     * The locale for the request.
+     *
+     * @var string
+     */
+    private string $locale;
+
+    public function __invoke(Request $request): JsonResponse
+    {
+        $this->currentVersion = $request->query('version') ?? (string) PHP_INT_MAX;
+        $this->locale = $request->query('locale') ?? '';
+
+        $response = new \stdClass();
+        $response->offers = $this->buildOffers();
+        $response->translations = $this->buildTranslations();
+
+        return response()->json($response);
+    }
+
+    private function buildOffers() : array
+    {
+        $offers = [];
+        $latestVersion = $this->getLatestVersion();
+
+        if ($this->locale) {
+            $offers[] = $this->buildTranslatedUpgradeOffer($latestVersion);
+
+            // When a translated offer is needed, the API only adds a 'latest' en_US offer
+            // if the currently installed version is not the latest version.
+            if ($this->currentVersion !== $latestVersion) {
+                $offers[] = $this->buildUpgradeOffer($latestVersion);
+            }
+        } else {
+            $offers[] = $this->buildUpgradeOffer($latestVersion);
+        }
+
+        // Versions older than 5.1.19 get an extra upgrade offer.
+        if (version_compare($this->currentVersion, '5.1.19', '<')) {
+            $offers[] = $this->buildAutoupdateOffer('5.1.19');
+        }
+
+        $olderVersions = $this->getOlderVersions();
+        foreach ($olderVersions as $olderVersion) {
+            $offers[] = $this->buildAutoupdateOffer($olderVersion);
+        }
+
+        return $offers;
+    }
+
+    private function buildTranslatedUpgradeOffer(string $version): \stdClass
+    {
+        $offer = $this->buildUpgradeOffer($version);
+        $offer->download = config('app.aspirecloud.download.base') . 'release/' . $this->locale . '/wordpress-' . $version . '.zip';
+        $offer->locale = $this->locale;
+
+        $offer->packages->full = config('app.aspirecloud.download.base') . 'release/' . $this->locale . '/wordpress-' . $version . '.zip';
+        $offer->packages->no_content = false;
+        $offer->packages->new_bundled = false;
+        $offer->packages->partial = false;
+        $offer->packages->rollback = false;
+
+        return $offer;
+    }
+
+    private function buildAutoupdateOffer(string $version): \stdClass
+    {
+        $offer = $this->buildUpgradeOffer($version);
+
+        $offer->response = 'autoupdate';
+        $offer->new_files = $this->getHasNewFiles($version);
+
+        return $offer;
+    }
+
+    private function buildUpgradeOffer(string $version): \stdClass
+    {
+        $offer = new \stdClass();
+
+        $offer->response = $this->currentVersion === $version ? 'latest' : 'upgrade';
+        $offer->download = config('app.aspirecloud.download.base') . 'release/wordpress-' . $version . '.zip';
+        $offer->locale = $offer->response === 'latest' && ! $this->locale ? false : 'en_US';
+
+        $offer->packages = new \stdClass();
+        $offer->packages->full = config('app.aspirecloud.download.base') . 'release/wordpress-' . $version . '.zip';
+        $offer->packages->no_content = config('app.aspirecloud.download.base') . 'release/wordpress-' . $version . '-no-content.zip';
+        $offer->packages->new_bundled = config('app.aspirecloud.download.base') . 'release/wordpress-' . $version . '-new-bundled.zip';
+
+        // Disabling these for now, pending more research from the team.
+        $offer->packages->partial = false;
+        $offer->packages->rollback = false;
+
+        $offer->current = $version;
+        $offer->version = $version;
+        $offer->php_version = $this->getPhpVersion($version);
+        $offer->mysql_version = $this->getMySqlVersion($version);
+        $offer->new_bundled = $this->getNewBundled();
+        $offer->partial_version = false;
+
+        return $offer;
+    }
+
+    private function buildTranslations() : array
+    {
+        if (! $this->locale) {
+            return [];
+        }
+
+        // There are other potential translations, possibly based on the slug.
+        // For now, this just generates a single translation package.
+        $translation = new \stdClass();
+        $translation->type = 'core';
+        $translation->slug = 'default';
+        $translation->language = $this->locale;
+        $translation->version = $this->currentVersion;
+        $translation->updated = '2023-10-01T00:00:00Z'; // Store in DB from the translations file. Pull from DB for here.
+        $translation->package = config('app.aspirecloud.download.base') . 'translation/core/' . $this->currentVersion . '/' . $this->locale . '.zip';
+        $translation->autoupdate = true;
+
+        return [ $translation ];
+    }
+
+    private function getLatestVersion(): string
+    {
+        // Probably pull from the database instead of hardcoding it.
+        return '6.8.1';
+    }
+
+    private function getLatestMajorVersion(): string
+    {
+        // Probably pull from the database instead of hardcoding it.
+        return '6.8';
+    }
+
+    private function getOlderVersions(): array
+    {
+        // Probably pull from the database instead of hardcoding these.
+        // Should have the latest minor from every branch.
+        // If not going for completeness, can probably remove the versions
+        // below AspireUpdate's minimum WP version (currently 5.3).
+        $map = [
+            '6.8.1', '6.8', '6.7.2', '6.6.2', '6.6.5', '6.4.5', '6.3.5', '6.2.6', '6.1.7', '6.0.9',
+            '5.9.10', '5.8.10', '5.7.12', '5.6.14', '5.5.15', '5.4.16', '5.3.18', '5.2.21', '5.1.19', '5.0.22',
+            '4.9.26', '4.8.25', '4.7.29', '4.6.29', '4.5.32', '4.4.33', '4.3.34', '4.2.38', '4.1.41', '4.0.38',
+            '3.9.40', '3.8.41', '3.7.41', '3.6.1', '3.5.2', '3.4.2', '3.3.3', '3.2.1', '3.1.4', '3.0.6',
+            '2.9.2', '2.8.6', '2.7.1', '2.6.5', '2.5.1', '2.3.3', '2.2.3', '2.1.3', '2.0.11',
+            '1.5.2', '1.2.2', '1.0.2',
+            '0.72',
+        ];
+
+        // If no version has been provided, all versions are considered older.
+        if ($this->currentVersion === (string) PHP_INT_MAX) {
+            return $map;
+        }
+
+        $versions = [];
+        foreach ($map as $version) {
+            if (version_compare($this->currentVersion, $version, '<')) {
+                $versions[] = $version;
+            }
+        }
+
+        return $versions;
+    }
+
+    private function getPhpVersion(string $version): string
+    {
+        // The WordPress versions that started a new minimum PHP version requirement.
+        $map = [
+            '6.6' => '7.2.24',
+            '6.3' => '7.0.0',
+            '5.2' => '5.6.20',
+            '4.1' => '5.2.4',
+        ];
+
+        foreach ($map as $wpMajor => $php) {
+            if (version_compare($version, $wpMajor, '>=')) {
+                return $php;
+            }
+        }
+
+        return end($map);
+    }
+
+    private function getMySqlVersion(string $version): string
+    {
+        // The WordPress versions that started a new minimum MySQL version requirement.
+        $map = [
+            '6.5' => '5.5.5',
+            '4.1' => '5.0',
+        ];
+
+        foreach ($map as $wpMajor => $mysql) {
+            if (version_compare($version, $wpMajor, '>=')) {
+                return $mysql;
+            }
+        }
+
+        return end($map);
+    }
+
+    private function getNewBundled(): string
+    {
+        // Appears to be the second latest major version.
+        $parts = explode('.', $this->getLatestMajorVersion());
+        if ($parts[1] > 0) {
+            --$parts[1];
+        } else {
+            $parts[1] = 9;
+            --$parts[0];
+        }
+
+        return $parts[0] . '.' . $parts[1];
+    }
+
+    private function getHasNewFiles(string $version): bool
+    {
+        // WP Core relaxes filesystem checks when the API
+        // specifies that it's safe to do.
+        // The API specifies this by setting new_files to false.
+        // For now, return true so filesystem checks are not relaxed.
+        return true;
+
+        // Appears to depend on a comparison between
+        // the installed version and the offered version.
+        $hasNewFiles = [];
+        return array_key_exists($version, $hasNewFiles);
+    }
+}

--- a/routes/api.php
+++ b/routes/api.php
@@ -5,6 +5,7 @@
 use App\Http\Controllers\API\WpOrg\Core\BrowseHappyController;
 use App\Http\Controllers\API\WpOrg\Core\ImportersController;
 use App\Http\Controllers\API\WpOrg\Core\ServeHappyController;
+use App\Http\Controllers\API\WpOrg\Core\VersionCheckController;
 use App\Http\Controllers\API\WpOrg\Plugins\PluginInformation_1_2_Controller;
 use App\Http\Controllers\API\WpOrg\Plugins\PluginUpdateCheck_1_1_Controller;
 use App\Http\Controllers\API\WpOrg\SecretKey\SecretKeyController;
@@ -29,6 +30,7 @@ Route::prefix('/')
         $router->any('/core/browse-happy/{version}', BrowseHappyController::class)->where(['version' => '1.1']);
         $router->any('/core/serve-happy/{version}', ServeHappyController::class)->where(['version' => '1.0']);
         $router->get('/core/importers/{version}', ImportersController::class)->where(['version' => '1.[01]']);
+        $router->any('/core/version-check/{version}', VersionCheckController::class)->where(['version' => '1.[67]']);
 
         $router->get('/plugins/info/1.2', PluginInformation_1_2_Controller::class);
         $router->post('/plugins/update-check/1.1', PluginUpdateCheck_1_1_Controller::class);
@@ -45,7 +47,6 @@ Route::prefix('/')
         $router->any('/core/credits/{version}', PassThroughController::class)->where(['version' => '1.[01]']);
         $router->any('/core/handbook/{version}', PassThroughController::class)->where(['version' => '1.0']);
         $router->any('/core/stable-check/{version}', PassThroughController::class)->where(['version' => '1.0']);
-        $router->any('/core/version-check/{version}', PassThroughController::class)->where(['version' => '1.[67]']);
 
         $router->any('/events/{version}', PassThroughController::class)->where(['version' => '1.0']);
 


### PR DESCRIPTION
# Pull Request

## What changed?

This introduces a partial controller implementation for `core/version-check`.

**Notes:**
- `partial` and `rollback` values aren't covered (yet, maybe?).
- I've opted for doing it all in a single controller file without DB integration because it's a first iteration and I'm honestly not sure of all of the implementation points within AspireCloud's architecture.
- The URLs are built using `config('app.aspirecloud.download.base')`. I think that's correct.
- My thinking is that, with the proper additional code, if a package isn't available at AspireCloud, it can be downloaded to AspireCloud for future requests.
- This PR may also serve as a reference point for an alternative PR.

## Did you fix any specific issues?

Related: #52 

## CERTIFICATION

By opening this pull request, I do agree to abide by the [Code of Conduct](https://github.com/aspirepress/.github/blob/updating-contributor-policy/CODE_OF_CONDUCT.md) and be bound by the terms of the [Contribution Guidelines](https://github.com/aspirepress/.github/blob/updating-contributor-policy/CONTRIBUTING.md) in effect on the date and time of my contribution as proven by the revision information in GitHub.

