### PR TITLE
fix multiple issues with PassThroughController

### DIFF
--- a/app/Http/Controllers/PassThroughController.php
+++ b/app/Http/Controllers/PassThroughController.php
@@ -40,6 +40,7 @@ class PassThroughController extends Controller
         return response($content, $response->status(), $response->headers());
     }
 
+    /** @return array<string, string> */
     private function filterRequestHeaders(Request $request): array
     {
         $headers = $request->headers->all();

--- a/app/Http/Controllers/PassThroughController.php
+++ b/app/Http/Controllers/PassThroughController.php
@@ -22,22 +22,39 @@ class PassThroughController extends Controller
             throw new \RuntimeException('Unexpected request to pass-through controller in testing environment');
         }
 
-        $requestData = $request->all();
-        $ua = $request->header('User-Agent');
         $path = $request->path();
         $queryParams = $request->query();
 
-        $response = Http::withHeaders(['User-Agent' => $ua, 'Accept' => '*/*'])
-            ->asForm()
+        $headers = $this->filterRequestHeaders($request);
+
+        $response = Http::withHeaders($headers)
+            ->withBody($request->getContent())
             ->send(
                 $request->getMethod(),
-                "https://api.wordpress.org/$path",
-                ['query' => $queryParams, 'form_params' => $requestData],
+                "https://api.wordpress.org/$path/", // always add the trailing /
+                ['query' => $queryParams],
             );
 
         $content = $response->body();
         $this->logRequestAndResponse($request, $response, $content);
-        return response($content, $response->status(), ['Content-Type', $response->header('Content-Type')]);
+        return response($content, $response->status(), $response->headers());
+    }
+
+    private function filterRequestHeaders(Request $request): array
+    {
+        $headers = $request->headers->all();
+
+        $filter = fn($value, $key) => match (true) {
+            $key === 'host', $key === 'content-length' => false,
+            str_starts_with($key, 'x-') => false,
+            default => true,
+        };
+
+        $mapWpHeader = fn($key) => str_starts_with($key, 'wp-') ? str_replace('-', '_', $key) : $key;
+
+        $mapHeaders = fn($value, $key) => [$mapWpHeader($key) => $value[0]];
+
+        return collect($headers)->filter($filter)->mapWithKeys($mapHeaders)->toArray();
     }
 
     private function logRequestAndResponse(Request $request, ClientResponse $response, string $content): void

--- a/app/Services/Plugins/QueryPluginsService.php
+++ b/app/Services/Plugins/QueryPluginsService.php
@@ -32,7 +32,7 @@ class QueryPluginsService
         $search and $callbacks->push(fn($query) => self::applySearchWeighted($query, $search, $req));
         $tag and $callbacks->push(fn($query) => self::applyTag($query, $tag));
         $author and $callbacks->push(fn($query) => self::applyAuthor($query, $author));
-        ($browse && !$search) and $callbacks->push(fn($query) => self::applyBrowse($query, $browse));
+        !$search and $callbacks->push(fn($query) => self::applyBrowse($query, $browse)); // search applies its own sort
 
         $query = $callbacks->reduce(fn($query, $callback) => $callback($query), Plugin::query());
         assert($query instanceof Builder);

--- a/phpstan.dist.neon
+++ b/phpstan.dist.neon
@@ -18,3 +18,6 @@ parameters:
 
         # BelongsToMany is totally broken with larastan now, but things are even more broken without it.
         - "#should return.*BelongsToMany<#"
+
+        # Builder's phpstan types are completely broken and there's nothing I can do about it.
+        - "#Builder does not specify its types: TModel#"


### PR DESCRIPTION
# Pull Request

## What changed?

* Request headers and body are passed through as unmolested as possible.
* Certain request headers like Content-Length are filtered out since they should be calculated by the http client.
* The trailing slash in the path that was stripped out by Laravel is added back to the request.
* The dubious `wp_blog` and similar headers are passed through, underscores and all (underscores are conventionally converted to dashes).
* All response headers are now passed back to the client as-is.

## Why did it change?

We were getting bad results for update searches because the backend was sending back a 301 redirect due to the lack of a trailing slash, thus converting the POST into a GET.  The proper status to return would be 307 but the .org code probably predates its existence.  And since we mangled the headers we sent back (accidentally sending a list back instead of an assoc array) we were returning the wrong content type.

## Did you fix any specific issues?

Closes: #167 

## CERTIFICATION

By opening this pull request, I do agree to abide by the [Code of Conduct](https://github.com/aspirepress/.github/blob/updating-contributor-policy/CODE_OF_CONDUCT.md) and be bound by the terms of the [Contribution Guidelines](https://github.com/aspirepress/.github/blob/updating-contributor-policy/CONTRIBUTING.md) in effect on the date and time of my contribution as proven by the revision information in GitHub.

