### PR TITLE
abort failed downloads with same status/reason as upstream response

### DIFF
--- a/app/Services/Downloads/DownloadService.php
+++ b/app/Services/Downloads/DownloadService.php
@@ -70,9 +70,9 @@ class DownloadService implements Downloader
 
         if (!$response->successful()) {
             $status = $response->status();
-            $message = "Download failed: [status: $status, url: $upstreamUrl]";
-            Log::error($message, [...$context, 'response' => $response]);
-            throw new \RuntimeException($message);
+            $reason = $response->getReasonPhrase();
+            Log::info("Asset download failed: $reason [url: $upstreamUrl]", [...$context, 'response' => $response]);
+            abort($status, $reason);
         }
 
         Log::debug("Saving $file downloaded from $upstreamUrl", $context);


### PR DESCRIPTION
# Pull Request

## What changed?

If asset download fails, abort the request with the same status (e.g. 404) instead of 500

## Why did it change?

more specific errors are good.

## Did you fix any specific issues?

none

## CERTIFICATION

By opening this pull request, I do agree to abide by the [Code of Conduct](https://github.com/aspirepress/.github/blob/updating-contributor-policy/CODE_OF_CONDUCT.md) and be bound by the terms of the [Contribution Guidelines](https://github.com/aspirepress/.github/blob/updating-contributor-policy/CONTRIBUTING.md) in effect on the date and time of my contribution as proven by the revision information in GitHub.

