### PR TITLE
GH-278: return all theme fields by default

### DIFF
--- a/app/Values/WpOrg/Plugins/QueryPluginsRequest.php
+++ b/app/Values/WpOrg/Plugins/QueryPluginsRequest.php
@@ -23,7 +23,7 @@ readonly class QueryPluginsRequest extends Bag
         public ?string $plugin = null,  // slug of a specific plugin
         public ?string $author = null,  // wp.org username of author
         public ?string $browse = null,  // one of popular|top-rated|updated|new
-        public mixed $fields = null,
+        public mixed $fields = null,    // ignored-- all fields are always returned
         public int $page = 1,
         public int $per_page = 24,
     ) {}

--- a/app/Values/WpOrg/Themes/ThemeFields.php
+++ b/app/Values/WpOrg/Themes/ThemeFields.php
@@ -6,7 +6,8 @@ use Illuminate\Http\Request;
 
 trait ThemeFields
 {
-    public const allFields = [
+    // does not include fields that are always enabled, e.g. slug, name
+    public const additionalFields = [
         'description' => false,
         'downloaded' => false,
         'download_link' => false,
@@ -47,28 +48,24 @@ trait ThemeFields
     public static function getFields(Request $request, array $defaultFields = []): array
     {
         if (version_compare($request->route('version'), '1.2', '>=')) {
-            $defaultFields['extended_author'] = true;
-            $defaultFields['external_repository_url'] = true;
-            $defaultFields['external_support_url'] = true;
-            $defaultFields['is_commercial'] = true;
-            $defaultFields['is_community'] = true;
-            $defaultFields['num_ratings'] = true;
-            $defaultFields['parent'] = true;
-            $defaultFields['requires'] = true;
-            $defaultFields['requires_php'] = true;
+            // GH-278: we send back all fields by default now.
+            // This makes much of the code below redundant, but we still want to support explicitly disabling fields
+            $defaultFields = array_fill_keys(array_keys(self::additionalFields), true);
 
-            // These aren't actually served in .org protocol version 1.2, but it's harmless to add them
-            // Eventually we'll just serve everything but sections and description by default.
-            $defaultFields['creation_time'] = true;
-            $defaultFields['download_link'] = true;
-            $defaultFields['last_updated_time'] = true;
-            $defaultFields['rating'] = true;
-            $defaultFields['ratings'] = true;
-            $defaultFields['upload_date'] = true;
+            // Default fields enabled by api.wordpress.org below
+            // $defaultFields['extended_author'] = true;
+            // $defaultFields['external_repository_url'] = true;
+            // $defaultFields['external_support_url'] = true;
+            // $defaultFields['is_commercial'] = true;
+            // $defaultFields['is_community'] = true;
+            // $defaultFields['num_ratings'] = true;
+            // $defaultFields['parent'] = true;
+            // $defaultFields['requires'] = true;
+            // $defaultFields['requires_php'] = true;
         }
         $specifiedFields = $request->query('fields');
-        if ($specifiedFields == null) {
-            return array_merge(self::allFields, $defaultFields);
+        if (!$specifiedFields) {
+            return array_merge(self::additionalFields, $defaultFields);
         }
 
         if (!is_array($specifiedFields)) {
@@ -94,6 +91,6 @@ trait ThemeFields
             }, $specifiedFields);
         }
 
-        return array_merge(self::allFields, $specifiedFields, $defaultFields);
+        return array_merge(self::additionalFields, $specifiedFields, $defaultFields);
     }
 }

--- a/tests/Feature/API/WpOrg/ThemeControllerTest.php
+++ b/tests/Feature/API/WpOrg/ThemeControllerTest.php
@@ -93,7 +93,7 @@ it('returns theme_information (v1.1)', function () {
         ]);
 });
 
-it('returns theme_information (v1.2)', function () {
+it('returns all fields in theme_information (v1.2)', function () {
     $response = $this->get('/themes/info/1.2?action=theme_information&slug=my-theme');
 
     $response
@@ -189,8 +189,12 @@ it('returns theme query results (v1.2)', function () {
                     'version' => '1.2.1',
                 ],
             ],
-        ]);
-
+        ])
+        // GH-278: return all fields.  these are not normally returned by default by .org
+        ->assertJsonPath('themes.0.download_link', 'https://api.aspiredev.org/download/my-theme')
+        ->assertJsonPath('themes.0.downloaded', 1000)
+        ->assertJsonPath('themes.0.active_installs', 100)
+        ->assertJsonPath('themes.0.tags.black', 'black');
 });
 
 it('returns theme query results for tag (v1.2)', function () {


### PR DESCRIPTION
# Pull Request

## What changed?

For `query_plugins` searches, all theme fields are now returned by default when using protocol version 1.2 or higher.  Fields can still be filtered out using `&fields[foo]=0` but this is likely to become unsupported in the future so that queries can be more easily cached. 

No changes were needed for plugin queries, because filtering out fields has never been supported for plugins, for any protocol version: all fields are always sent.

## Why did it change?

The biggest field that themes have, `description` is already sent in query results, so it seems silly to leave so many others out, especially when responses are already transferred with gzip encoding.

## Did you fix any specific issues?

Closes: #278 

## CERTIFICATION

By opening this pull request, I do agree to abide by the [Code of Conduct](https://github.com/aspirepress/.github/blob/updating-contributor-policy/CODE_OF_CONDUCT.md) and be bound by the terms of the [Contribution Guidelines](https://github.com/aspirepress/.github/blob/updating-contributor-policy/CONTRIBUTING.md) in effect on the date and time of my contribution as proven by the revision information in GitHub.

