### PR TITLE
Support AND-ed ac_tags[] in theme queries

### DIFF
--- a/app/Services/Themes/QueryThemesService.php
+++ b/app/Services/Themes/QueryThemesService.php
@@ -26,7 +26,9 @@ class QueryThemesService
             ->when($search, self::applySearch(...))
             ->when($req->theme, self::applyTheme(...))
             ->when($author, self::applyAuthor(...))
-            ->when($req->tags, self::applyTags(...));
+            ->when($req->tags, self::applyTags(...))
+            ->when($req->ac_tags, self::applyAcTags(...));
+
 
         $total = $themesBaseQuery->count();
 
@@ -96,6 +98,17 @@ class QueryThemesService
     private static function applyTags(Builder $query, array $tags): void
     {
         $query->whereHas('tags', fn(Builder $q) => $q->whereIn('slug', $tags));
+    }
+
+    /**
+     * @param Builder<Theme> $query
+     * @param string[]       $ac_tags
+     */
+    private static function applyAcTags(Builder $query, array $ac_tags): void
+    {
+        foreach ($ac_tags as $tag) {
+            $query->whereHas('tags', fn(Builder $q) => $q->where('slug', $tag));
+        }
     }
 
     private static function normalizeSearchString(?string $search): ?string

--- a/app/Values/WpOrg/Themes/QueryThemesRequest.php
+++ b/app/Values/WpOrg/Themes/QueryThemesRequest.php
@@ -28,6 +28,9 @@ readonly class QueryThemesRequest extends Bag
         public mixed $fields = null,
         public int $page = 1,
         public int $per_page = 24,
+
+        // AspireCloud-specific extensions
+        public ?array $ac_tags = null, // tag or set of tags, AND'ed together
     ) {}
 
     /** @return array<string, mixed> */
@@ -37,6 +40,7 @@ readonly class QueryThemesRequest extends Bag
         $query = $request->query();
 
         $query['tags'] = (array)Arr::pull($query, 'tag', []);
+        $query['ac_tags'] = (array)Arr::pull($query, 'ac_tag', []);
 
         $defaultFields = [
             'description' => true,

--- a/tests/Feature/API/WpOrg/ThemeControllerTest.php
+++ b/tests/Feature/API/WpOrg/ThemeControllerTest.php
@@ -197,9 +197,9 @@ it('returns theme query results (v1.2)', function () {
         ->assertJsonPath('themes.0.tags.black', 'black');
 });
 
-it('returns theme query results for tag (v1.2)', function () {
+it('returns theme query results for tags (v1.2)', function () {
     $this
-        ->get('/themes/info/1.2?action=query_themes&tag=black')
+        ->get('/themes/info/1.2?action=query_themes&tag[]=black&tag[]=orange')
         ->assertStatus(200)
         ->assertJson([
             'info' => ['page' => 1, 'pages' => 1, 'results' => 1],
@@ -228,6 +228,66 @@ it('returns theme query results for tag (v1.2)', function () {
                     'version' => '1.2.1',
                 ],
             ],
+        ]);
+
+    $this
+        ->get('/themes/info/1.2?action=query_themes&tag=orange')
+        ->assertStatus(200)
+        ->assertExactJson([
+            'info' => ['page' => 1, 'pages' => 0, 'results' => 0],  // page 1 of 0 is a bit odd but it is correct
+            'themes' => [],
+        ]);
+});
+
+it('returns theme query results for ac_tags (v1.2)', function () {
+    $this
+        ->get('/themes/info/1.2?action=query_themes&ac_tag[]=black&ac_tag[]=blue')
+        ->assertStatus(200)
+        ->assertJson([
+            'info' => ['page' => 1, 'pages' => 1, 'results' => 1],
+            'themes' => [
+                [
+                    'author' => [
+                        'author' => 'Tmeister',
+                        'author_url' => 'https://wp-themes.com/author/tmeister',
+                        'avatar' => 'https://avatars.wp.org/tmeister',
+                        'display_name' => 'Tmeister',
+                        'profile' => 'https://profiles.wp.org/tmeister',
+                        'user_nicename' => 'tmeister',
+                    ],
+                    'description' => 'My Theme',
+                    'external_repository_url' => 'https://test.com',
+                    'homepage' => 'https://wordpress.org/themes/my-theme/',
+                    'is_commercial' => false,
+                    'is_community' => true,
+                    'name' => 'My Theme',
+                    'num_ratings' => 6,
+                    'preview_url' => 'https://wp-themes.com/my-theme',
+                    'rating' => 5,
+                    'requires_php' => '5.6',
+                    'screenshot_url' => 'https://wp-themes.com/my-theme/screenshot.png',
+                    'slug' => 'my-theme',
+                    'version' => '1.2.1',
+                ],
+            ],
+        ]);
+
+    $this
+        ->get('/themes/info/1.2?action=query_themes&tag=orange')
+        ->assertStatus(200)
+        ->assertExactJson([
+            'info' => ['page' => 1, 'pages' => 0, 'results' => 0],  // page 1 of 0 is a bit odd but it is correct
+            'themes' => [],
+        ]);
+});
+
+it('ANDs together ac_tags (v1.2)', function () {
+    $this
+        ->get('/themes/info/1.2?action=query_themes&ac_tag[]=black&ac_tag[]=orange')
+        ->assertStatus(200)
+        ->assertJson([
+            'info' => ['page' => 1, 'pages' => 0, 'results' => 0],
+            'themes' => [],
         ]);
 
     $this


### PR DESCRIPTION
# Pull Request

## What changed?

Adds support for an `ac_tags` parameter to theme queries.  Unlike the normal `tags` parameter, `ac_tags` are ANDed together and not OR'd, which is usually what you want with a tag search.  The .org search implementation does bump up results that match all tags over results that match fewer, and that's not entirely bad, but `ac_tags` represents a hard filter, and so will any future `ac_*` parameter (if we want fuzzy, we'll ask for it.

This is for themes only: the design of plugin search will need some refactoring to distribute criteria like this across every sub-query, and I'd like to ship the feature for themes before I can get to that.

## Why did it change?

To give AE an unfair advantage by embracing and extending the .org protocol 😜

## Did you fix any specific issues?

none

## CERTIFICATION

By opening this pull request, I do agree to abide by the [Code of Conduct](https://github.com/aspirepress/.github/blob/updating-contributor-policy/CODE_OF_CONDUCT.md) and be bound by the terms of the [Contribution Guidelines](https://github.com/aspirepress/.github/blob/updating-contributor-policy/CONTRIBUTING.md) in effect on the date and time of my contribution as proven by the revision information in GitHub.

