### PR TITLE
add base DTO class, add ToJsonPretty trait

### DIFF
--- a/app/Utils/ToJsonPretty.php
+++ b/app/Utils/ToJsonPretty.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Utils;
+
+/**
+ * In addition to adding the JSON_PRETTY_PRINT and JSON_UNESCAPED_* flags, this also sets JSON_THROW_ON_ERROR,
+ * which any sane consumer of this traight ought to be doing in the first place.
+ */
+trait ToJsonPretty
+{
+    public const DEFAULT_FLAGS = JSON_THROW_ON_ERROR
+    | JSON_PRETTY_PRINT
+    | JSON_UNESCAPED_SLASHES
+    | JSON_UNESCAPED_UNICODE;
+
+    public function toJson($options = 0): string|false
+    {
+        return parent::toJson($options | self::DEFAULT_FLAGS);
+    }
+}

--- a/app/Values/DTO.php
+++ b/app/Values/DTO.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Values;
+
+use App\Utils\ToJsonPretty;
+use Bag\Bag;
+
+abstract readonly class DTO extends Bag
+{
+    use ToJsonPretty;
+}

--- a/app/Values/DTO.php
+++ b/app/Values/DTO.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace App\Values;
 
-use App\Utils\ToJsonPretty;
 use Bag\Bag;
 
 abstract readonly class DTO extends Bag

--- a/app/Values/ToJsonPretty.php
+++ b/app/Values/ToJsonPretty.php
@@ -2,7 +2,9 @@
 
 declare(strict_types=1);
 
-namespace App\Utils;
+namespace App\Values;
+
+use Override;
 
 /**
  * In addition to adding the JSON_PRETTY_PRINT and JSON_UNESCAPED_* flags, this also sets JSON_THROW_ON_ERROR,
@@ -15,6 +17,7 @@ trait ToJsonPretty
     | JSON_UNESCAPED_SLASHES
     | JSON_UNESCAPED_UNICODE;
 
+    #[Override]
     public function toJson($options = 0): string|false
     {
         return parent::toJson($options | self::DEFAULT_FLAGS);

--- a/app/Values/WpOrg/Author.php
+++ b/app/Values/WpOrg/Author.php
@@ -3,10 +3,10 @@
 namespace App\Values\WpOrg;
 
 use App\Models\WpOrg\Author as AuthorModel;
+use App\Values\DTO;
 use Bag\Attributes\Transforms;
-use Bag\Bag;
 
-readonly class Author extends Bag
+readonly class Author extends DTO
 {
     public function __construct(
         public string $user_nicename,

--- a/app/Values/WpOrg/PageInfo.php
+++ b/app/Values/WpOrg/PageInfo.php
@@ -2,9 +2,9 @@
 
 namespace App\Values\WpOrg;
 
-use Bag\Bag;
+use App\Values\DTO;
 
-readonly class PageInfo extends Bag
+readonly class PageInfo extends DTO
 {
     public function __construct(
         public int $page,

--- a/app/Values/WpOrg/Plugins/ClosedPluginResponse.php
+++ b/app/Values/WpOrg/Plugins/ClosedPluginResponse.php
@@ -5,10 +5,10 @@ declare(strict_types=1);
 namespace App\Values\WpOrg\Plugins;
 
 use App\Models\WpOrg\ClosedPlugin;
+use App\Values\DTO;
 use Bag\Attributes\Transforms;
-use Bag\Bag;
 
-readonly class ClosedPluginResponse extends Bag
+readonly class ClosedPluginResponse extends DTO
 {
     public function __construct(
         public string $name,

--- a/app/Values/WpOrg/Plugins/PluginHotTagsResponse.php
+++ b/app/Values/WpOrg/Plugins/PluginHotTagsResponse.php
@@ -3,10 +3,10 @@
 namespace App\Values\WpOrg\Plugins;
 
 use App\Models\WpOrg\PluginTag;
+use App\Values\DTO;
 use Bag\Attributes\Transforms;
-use Bag\Bag;
 
-readonly class PluginHotTagsResponse extends Bag
+readonly class PluginHotTagsResponse extends DTO
 {
     public function __construct(
         public string $slug,

--- a/app/Values/WpOrg/Plugins/PluginInformationRequest.php
+++ b/app/Values/WpOrg/Plugins/PluginInformationRequest.php
@@ -2,14 +2,14 @@
 
 namespace App\Values\WpOrg\Plugins;
 
+use App\Values\DTO;
 use Bag\Attributes\StripExtraParameters;
 use Bag\Attributes\Transforms;
-use Bag\Bag;
 use Illuminate\Http\Request;
 
 // Far simpler than ThemeInformationRequest, it takes a slug and that's it
 #[StripExtraParameters]
-readonly class PluginInformationRequest extends Bag
+readonly class PluginInformationRequest extends DTO
 {
     public const ACTION = 'plugin_information';
 

--- a/app/Values/WpOrg/Plugins/PluginResponse.php
+++ b/app/Values/WpOrg/Plugins/PluginResponse.php
@@ -5,12 +5,12 @@ declare(strict_types=1);
 namespace App\Values\WpOrg\Plugins;
 
 use App\Models\WpOrg\Plugin;
+use App\Values\DTO;
 use Bag\Attributes\Transforms;
-use Bag\Bag;
 use Bag\Values\Optional;
 use DateTimeInterface;
 
-readonly class PluginResponse extends Bag
+readonly class PluginResponse extends DTO
 {
     public const LAST_UPDATED_DATE_FORMAT = 'Y-m-d h:ia T'; // .org's goofy format: "2024-09-27 9:53pm GMT"
 

--- a/app/Values/WpOrg/Plugins/PluginUpdateCheckRequest.php
+++ b/app/Values/WpOrg/Plugins/PluginUpdateCheckRequest.php
@@ -2,8 +2,8 @@
 
 namespace App\Values\WpOrg\Plugins;
 
+use App\Values\DTO;
 use Bag\Attributes\Transforms;
-use Bag\Bag;
 use Illuminate\Http\Request;
 
 use function Safe\json_decode;
@@ -16,7 +16,7 @@ use function Safe\json_decode;
  *     X-Generator: string
  * }
  */
-readonly class PluginUpdateCheckRequest extends Bag
+readonly class PluginUpdateCheckRequest extends DTO
 {
     /**
      * @param array<string, array{"Version": string}> $plugins

--- a/app/Values/WpOrg/Plugins/PluginUpdateCheckResponse.php
+++ b/app/Values/WpOrg/Plugins/PluginUpdateCheckResponse.php
@@ -2,11 +2,11 @@
 
 namespace App\Values\WpOrg\Plugins;
 
-use Bag\Bag;
+use App\Values\DTO;
 use Bag\Values\Optional;
 use Illuminate\Support\Collection;
 
-readonly class PluginUpdateCheckResponse extends Bag
+readonly class PluginUpdateCheckResponse extends DTO
 {
     /**
      * @param Collection<string, PluginUpdateData> $plugins

--- a/app/Values/WpOrg/Plugins/PluginUpdateData.php
+++ b/app/Values/WpOrg/Plugins/PluginUpdateData.php
@@ -3,11 +3,11 @@
 namespace App\Values\WpOrg\Plugins;
 
 use App\Models\WpOrg\Plugin;
+use App\Values\DTO;
 use Bag\Attributes\Transforms;
-use Bag\Bag;
 use Bag\Values\Optional;
 
-readonly class PluginUpdateData extends Bag
+readonly class PluginUpdateData extends DTO
 {
     /**
      * @param Optional|list<string> $requires_plugins

--- a/app/Values/WpOrg/Plugins/QueryPluginsRequest.php
+++ b/app/Values/WpOrg/Plugins/QueryPluginsRequest.php
@@ -4,9 +4,9 @@ declare(strict_types=1);
 
 namespace App\Values\WpOrg\Plugins;
 
+use App\Values\DTO;
 use Bag\Attributes\StripExtraParameters;
 use Bag\Attributes\Transforms;
-use Bag\Bag;
 use Illuminate\Http\Request;
 use Illuminate\Support\Arr;
 
@@ -14,7 +14,7 @@ use Illuminate\Support\Arr;
 // I'd look into refactoring it, but it's not like .org is going to add a new resource type anytime soon.
 // We can clean things up in the 2.0 API.
 #[StripExtraParameters]
-readonly class QueryPluginsRequest extends Bag
+readonly class QueryPluginsRequest extends DTO
 {
     /** @param list<string>|null $tags */
     public function __construct(

--- a/app/Values/WpOrg/Plugins/QueryPluginsResponse.php
+++ b/app/Values/WpOrg/Plugins/QueryPluginsResponse.php
@@ -4,11 +4,11 @@ declare(strict_types=1);
 
 namespace App\Values\WpOrg\Plugins;
 
+use App\Values\DTO;
 use App\Values\WpOrg\PageInfo;
-use Bag\Bag;
 use Bag\Collection;
 
-readonly class QueryPluginsResponse extends Bag
+readonly class QueryPluginsResponse extends DTO
 {
     public function __construct(
         public Collection $plugins,

--- a/app/Values/WpOrg/Themes/QueryThemesRequest.php
+++ b/app/Values/WpOrg/Themes/QueryThemesRequest.php
@@ -2,14 +2,14 @@
 
 namespace App\Values\WpOrg\Themes;
 
+use App\Values\DTO;
 use Bag\Attributes\StripExtraParameters;
 use Bag\Attributes\Transforms;
-use Bag\Bag;
 use Illuminate\Http\Request;
 use Illuminate\Support\Arr;
 
 #[StripExtraParameters]
-readonly class QueryThemesRequest extends Bag
+readonly class QueryThemesRequest extends DTO
 {
     use ThemeFields;
 

--- a/app/Values/WpOrg/Themes/QueryThemesResponse.php
+++ b/app/Values/WpOrg/Themes/QueryThemesResponse.php
@@ -4,11 +4,11 @@ declare(strict_types=1);
 
 namespace App\Values\WpOrg\Themes;
 
+use App\Values\DTO;
 use App\Values\WpOrg\PageInfo;
-use Bag\Bag;
 use Bag\Collection;
 
-readonly class QueryThemesResponse extends Bag
+readonly class QueryThemesResponse extends DTO
 {
     public function __construct(
         public Collection $themes,

--- a/app/Values/WpOrg/Themes/ThemeHotTagsResponse.php
+++ b/app/Values/WpOrg/Themes/ThemeHotTagsResponse.php
@@ -3,10 +3,10 @@
 namespace App\Values\WpOrg\Themes;
 
 use App\Models\WpOrg\ThemeTag;
+use App\Values\DTO;
 use Bag\Attributes\Transforms;
-use Bag\Bag;
 
-readonly class ThemeHotTagsResponse extends Bag
+readonly class ThemeHotTagsResponse extends DTO
 {
     public function __construct(
         public string $slug,

--- a/app/Values/WpOrg/Themes/ThemeInformationRequest.php
+++ b/app/Values/WpOrg/Themes/ThemeInformationRequest.php
@@ -2,12 +2,12 @@
 
 namespace App\Values\WpOrg\Themes;
 
+use App\Values\DTO;
 use Bag\Attributes\StripExtraParameters;
-use Bag\Bag;
 use Illuminate\Http\Request;
 
 #[StripExtraParameters]
-readonly class ThemeInformationRequest extends Bag
+readonly class ThemeInformationRequest extends DTO
 {
     use ThemeFields;
 

--- a/app/Values/WpOrg/Themes/ThemeResponse.php
+++ b/app/Values/WpOrg/Themes/ThemeResponse.php
@@ -5,14 +5,14 @@ declare(strict_types=1);
 namespace App\Values\WpOrg\Themes;
 
 use App\Models\WpOrg\Theme;
+use App\Values\DTO;
 use App\Values\WpOrg\Author;
 use Bag\Attributes\Hidden;
 use Bag\Attributes\Transforms;
-use Bag\Bag;
 use Bag\Values\Optional;
 use Illuminate\Support\Arr;
 
-readonly class ThemeResponse extends Bag
+readonly class ThemeResponse extends DTO
 {
     /**
      * @param Optional|array{'1': int, '2': int, '3': int, '4': int, '5': int, } $ratings

--- a/app/Values/WpOrg/Themes/ThemeUpdateCheckRequest.php
+++ b/app/Values/WpOrg/Themes/ThemeUpdateCheckRequest.php
@@ -2,8 +2,8 @@
 
 namespace App\Values\WpOrg\Themes;
 
+use App\Values\DTO;
 use Bag\Attributes\Transforms;
-use Bag\Bag;
 use Illuminate\Http\Request;
 
 use function Safe\json_decode;
@@ -16,7 +16,7 @@ use function Safe\json_decode;
  *     X-Generator: string
  * }
  */
-readonly class ThemeUpdateCheckRequest extends Bag
+readonly class ThemeUpdateCheckRequest extends DTO
 {
     /**
      * @param string $active slug of currently active theme

--- a/app/Values/WpOrg/Themes/ThemeUpdateCheckResponse.php
+++ b/app/Values/WpOrg/Themes/ThemeUpdateCheckResponse.php
@@ -3,10 +3,10 @@
 namespace App\Values\WpOrg\Themes;
 
 use App\Models\WpOrg\Theme;
-use Bag\Bag;
+use App\Values\DTO;
 use Illuminate\Support\Collection;
 
-readonly class ThemeUpdateCheckResponse extends Bag
+readonly class ThemeUpdateCheckResponse extends DTO
 {
     /**
      * @param Collection<string, ThemeUpdateData> $themes

--- a/app/Values/WpOrg/Themes/ThemeUpdateData.php
+++ b/app/Values/WpOrg/Themes/ThemeUpdateData.php
@@ -3,10 +3,10 @@
 namespace App\Values\WpOrg\Themes;
 
 use App\Models\WpOrg\Theme;
+use App\Values\DTO;
 use Bag\Attributes\Transforms;
-use Bag\Bag;
 
-readonly class ThemeUpdateData extends Bag
+readonly class ThemeUpdateData extends DTO
 {
     public function __construct(
         public string $name,


### PR DESCRIPTION
# Pull Request

## What changed?

This adds a new abstract base class, `App\Values\DTO` which all of our DTOs now use instead of directly inheriting `Bag\Bag`.   I didn't like calling it `Value`, and almost went with `VO` but DTO is a more familiar term. 

This base class mixes in a new trait, `ToJsonPretty`, which overrides Bag's toJson() method with one that pretty-prints and doesn't unnecessarily escape data that's only ever consumed by an API client.  It also stealthily enables JSON_THROW_ON_ERROR, which every sane json api should be doing by default anyway.

## Why did it change?

better looking, better safety.  as a bonus, urls are now nice and clicky in the terminal.

## Did you fix any specific issues?

none

## CERTIFICATION

By opening this pull request, I do agree to abide by the [Code of Conduct](https://github.com/aspirepress/.github/blob/updating-contributor-policy/CODE_OF_CONDUCT.md) and be bound by the terms of the [Contribution Guidelines](https://github.com/aspirepress/.github/blob/updating-contributor-policy/CONTRIBUTING.md) in effect on the date and time of my contribution as proven by the revision information in GitHub.

