### PR TITLE
Use contributors metadata on plugins to enable author search

### DIFF
--- a/app/Http/Controllers/API/WpOrg/Plugins/PluginInformation_1_2_Controller.php
+++ b/app/Http/Controllers/API/WpOrg/Plugins/PluginInformation_1_2_Controller.php
@@ -44,7 +44,7 @@ class PluginInformation_1_2_Controller extends Controller
             $resource = ClosedPluginResponse::from($plugin);
             $status = 404;
         } else {
-            $resource = PluginResponse::from($plugin)->asPluginInformationResponse();
+            $resource = PluginResponse::from($plugin);
             $status = 200;
         }
         return response()->json($resource, $status);

--- a/app/Models/WpOrg/Author.php
+++ b/app/Models/WpOrg/Author.php
@@ -4,6 +4,8 @@ namespace App\Models\WpOrg;
 
 use App\Models\BaseModel;
 use Illuminate\Database\Eloquent\Concerns\HasUuids;
+use Illuminate\Database\Eloquent\Relations\BelongsToMany;
+use App\Models\WpOrg\Plugin;
 
 /**
  * @property-read string $id
@@ -31,5 +33,11 @@ class Author extends BaseModel
             'author' => 'string',
             'author_url' => 'string',
         ];
+    }
+
+    /** @return BelongsToMany<Plugin, covariant self> */
+    public function plugins(): BelongsToMany
+    {
+        return $this->belongsToMany(Plugin::class, 'plugin_authors', 'author_id', 'plugin_id', 'id', 'id');
     }
 }

--- a/app/Services/Plugins/QueryPluginsService.php
+++ b/app/Services/Plugins/QueryPluginsService.php
@@ -41,6 +41,7 @@ class QueryPluginsService
         $totalPages = (int)ceil($total / $perPage);
 
         $plugins = $query
+            ->with('contributors')
             ->offset(($page - 1) * $perPage)
             ->limit($perPage)
             ->get()

--- a/app/Values/WpOrg/Plugins/PluginResponse.php
+++ b/app/Values/WpOrg/Plugins/PluginResponse.php
@@ -104,13 +104,13 @@ readonly class PluginResponse extends DTO
             'donate_link' => $plugin->donate_link,
             'requires_plugins' => $plugin->requires_plugins,
 
-            // query_plugins only
+            // (formerly) query_plugins only
             'downloaded' => $plugin->downloaded,
             'short_description' => $plugin->short_description,
             'description' => $plugin->description,
             'icons' => $plugin->icons,
 
-            // plugin_information only
+            // (formerly) plugin_information only
             'sections' => $plugin->sections,
             'versions' => $plugin->versions,
             'contributors' => $plugin->contributors->mapWithKeys(
@@ -129,35 +129,6 @@ readonly class PluginResponse extends DTO
             'ac_origin' => $plugin->ac_origin,
             'ac_created' => $plugin->ac_created,
         ];
-    }
-
-    public function asQueryPluginsResponse(): static
-    {
-        $none = new Optional();
-        return $this->with([
-            'sections' => $none,
-            'versions' => $none,
-            'contributors' => $none,
-            'screenshots' => $none,
-            'support_url' => $none,
-            'upgrade_notice' => $none,
-            'business_model' => $none,
-            'repository_url' => $none,
-            'commercial_support_url' => $none,
-            'banners' => $none,
-            'preview_link' => $none,
-        ]);
-    }
-
-    public function asPluginInformationResponse(): static
-    {
-        $none = new Optional();
-        return $this->with([
-            'downloaded' => $none,
-            'short_description' => $none,
-            'description' => $none,
-            'icons' => $none,
-        ]);
     }
 
     private static function formatLastUpdated(?DateTimeInterface $lastUpdated): ?string

--- a/app/Values/WpOrg/Plugins/PluginResponse.php
+++ b/app/Values/WpOrg/Plugins/PluginResponse.php
@@ -6,6 +6,7 @@ namespace App\Values\WpOrg\Plugins;
 
 use App\Models\WpOrg\Plugin;
 use App\Values\DTO;
+use App\Values\WpOrg\Author;
 use Bag\Attributes\Transforms;
 use Bag\Values\Optional;
 use DateTimeInterface;
@@ -17,7 +18,7 @@ readonly class PluginResponse extends DTO
     /**
      * @param array<array-key, mixed> $banners
      * @param array<array-key, array{src: string, caption: string}> $screenshots
-     * @param array<string, mixed> $contributors
+     * @param array<string, Author> $contributors
      * @param array<string, string> $versions
      * @param array<string, string> $sections
      * @param array{"1":int, "2":int, "3":int, "4":int, "5":int} $ratings
@@ -112,7 +113,9 @@ readonly class PluginResponse extends DTO
             // plugin_information only
             'sections' => $plugin->sections,
             'versions' => $plugin->versions,
-            'contributors' => $plugin->contributors,
+            'contributors' => $plugin->contributors->mapWithKeys(
+                fn($authorModel) => [$authorModel->user_nicename => Author::from($authorModel)],
+            )->toArray(),
             'screenshots' => $plugin->screenshots,
             'support_url' => $plugin->support_url,
             'upgrade_notice' => $plugin->upgrade_notice ?: $none,

--- a/database/migrations/2025_06_19_195416_create_plugin_authors_table.php
+++ b/database/migrations/2025_06_19_195416_create_plugin_authors_table.php
@@ -1,0 +1,21 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    public function up(): void
+    {
+        Schema::create('plugin_authors', function (Blueprint $table) {
+            $table->foreignUuid('plugin_id')->references('id')->on('plugins')->onDelete('cascade');
+            $table->foreignUuid('author_id')->references('id')->on('authors')->onDelete('cascade');
+            $table->primary(['plugin_id', 'author_id']);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('plugin_authors');
+    }
+};

--- a/tests/Feature/API/WpOrg/PluginInformation_1_2_ControllerTest.php
+++ b/tests/Feature/API/WpOrg/PluginInformation_1_2_ControllerTest.php
@@ -2,6 +2,7 @@
 
 use App\Models\WpOrg\ClosedPlugin;
 use App\Models\WpOrg\Plugin;
+use App\Values\WpOrg\Plugins\PluginResponse;
 use Carbon\Carbon;
 use Illuminate\Testing\Fluent\AssertableJson;
 
@@ -115,6 +116,108 @@ it('returns plugin information in wp.org format', function () {
                     'versions' => 'array',
                 ]),
         );
+});
+
+// this test probably belongs elsewhere, but the whole suite is in need of some refactoring...
+it('returns plugin contributors in wp.org format', function () {
+    $md_0errors = [
+        'slug' => '0-errors',
+        'name' => '0-Errors',
+        'status' => 'open',
+        'version' => '0.2',
+        'author' => '<a href="http://zanto.org/">Ayebare Mucunguzi</a>',
+        'author_profile' => 'https://profiles.wordpress.org/brooksx/',
+        'contributors' => [
+            'brooksx' => [
+                'profile' => 'https://profiles.wordpress.org/brooksx/',
+                'avatar' => 'https://secure.gravatar.com/avatar/4fa021b564189f92bf90322a1215401d?s=96&d=monsterid&r=g',
+                'display_name' => 'Ayebare Mucunguzi Brooks',
+            ],
+        ],
+        'requires' => '3.1',
+        'tested' => '4.1.41',
+        'requires_php' => false,
+        'requires_plugins' => [],
+        'compatibility' => [],
+        'rating' => 100,
+        'ratings' => [
+            '5' => 1,
+            '4' => 0,
+            '3' => 0,
+            '2' => 0,
+            '1' => 0,
+        ],
+        'num_ratings' => 1,
+        'support_url' => 'https://wordpress.org/support/plugin/0-errors/',
+        'support_threads' => 0,
+        'support_threads_resolved' => 0,
+        'active_installs' => 10,
+        'downloaded' => 2616,
+        'last_updated' => '2015-01-28 9:41pm GMT',
+        'added' => '2015-01-20',
+        'homepage' => 'http://example.org/',
+        'sections' => [
+            'description' => '<p>This plugin makes it easy to work with WordPress with-ought the errors messing up the layout as they are nicely hidden in a drop down panel. Also PHP Errors are only shown to the admin and won&#8217;t be visible to the general public. There options to send the admin an email informing him of an error that has occurred on the site. The plugin has options of intercepting Ajax errors and PHP errors generated during Javascript requests and saving them to be viewed for debugging.</p><h3>Features</h3><ul><li>Show PHP errors only to the admin and hide them from the general public</li><li>Prevents PHP errors from breaking the site by displaying them in a drop down panel</li><li>Report PHP site errors to the admin by email</li><li>Capture PHP errors generated during ajax or Javascript requests to be viewed for debugging.</li></ul>',
+            'installation' => '<p>Upload the 0-Errors Plugin Base plugin to your blog and activate it. It would work as is.</p>',
+            'faq' => '<h4>Is it compatible with latest WordPress?</h4><p><p>Yes, it is, as well as with the latest PHP.</p></p>',
+            'changelog' => '<h4>0.2</h4><ul><li>Bug fixes</li></ul><h4>0.1</h4><ul><li>Initial commit</li></ul>',
+            'reviews' => '',
+        ],
+        'short_description' => 'Shows generated php site errors only to the admin via a drop down panel and hides them from the public. Email Alerts the admin of errors.',
+        'description' => '<p>This plugin makes it easy to work with WordPress with-ought the errors messing up the layout as they are nicely hidden in a drop down panel. Also PHP Errors are only shown to the admin and won&#8217;t be visible to the general public. There options to send the admin an email informing him of an error that has occurred on the site. The plugin has options of intercepting Ajax errors and PHP errors generated during Javascript requests and saving them to be viewed for debugging.</p><h3>Features</h3><ul><li>Show PHP errors only to the admin and hide them from the general public</li><li>Prevents PHP errors from breaking the site by displaying them in a drop down panel</li><li>Report PHP site errors to the admin by email</li><li>Capture PHP errors generated during ajax or Javascript requests to be viewed for debugging.</li></ul>',
+        'download_link' => 'https://downloads.wordpress.org/plugin/0-errors.0.2.zip',
+        'upgrade_notice' => [],
+        'screenshots' => [],
+        'tags' => [
+            'debug' => 'debug',
+            'email-errors' => 'email errors',
+            'errors' => 'errors',
+            'error_reporting' => 'error_reporting',
+        ],
+        'versions' => [
+            '0.1' => 'https://downloads.wordpress.org/plugin/0-errors.0.1.zip',
+            '0.2' => 'https://downloads.wordpress.org/plugin/0-errors.0.2.zip',
+            'trunk' => 'https://downloads.wordpress.org/plugin/0-errors.zip',
+        ],
+        'business_model' => false,
+        'repository_url' => '',
+        'commercial_support_url' => '',
+        'donate_link' => '',
+        'banners' => [],
+        'icons' => [
+            'default' => 'https://s.w.org/plugins/geopattern-icon/0-errors.svg',
+        ],
+        'author_block_count' => 0,
+        'author_block_rating' => 100,
+        'preview_link' => '',
+        'aspiresync_meta' => [
+            'id' => '01933d0c-12a5-71f0-95eb-f6a036e963bb',
+            'type' => 'plugin',
+            'slug' => '0-errors',
+            'name' => '0-Errors',
+            'status' => 'open',
+            'version' => '0.2',
+            'origin' => 'wp_org',
+            'updated' => '2015-01-28T21:41:00+00:00',
+            'pulled' => '2024-11-18T02:13:41+00:00',
+        ],
+    ];
+
+    $plugin = Plugin::fromSyncMetadata($md_0errors);
+
+    $response = PluginResponse::from($plugin);
+
+    expect($response->contributors)
+        ->toMatchArray([
+            'brooksx' => [
+                'profile' => 'https://profiles.wordpress.org/brooksx/',
+                'avatar' => 'https://secure.gravatar.com/avatar/4fa021b564189f92bf90322a1215401d?s=96&d=monsterid&r=g',
+                'display_name' => 'Ayebare Mucunguzi Brooks',
+                'author' => null,
+                'author_url' => null,
+                'user_nicename' => 'brooksx',
+            ],
+        ]);
 });
 
 it('returns closed plugin information in wp.org format', function () {

--- a/tests/Feature/Sync/SyncPluginTest.php
+++ b/tests/Feature/Sync/SyncPluginTest.php
@@ -104,12 +104,11 @@ describe('Sync Plugins', function () {
             )
             ->and($plugin->author)->toBe('<a href="http://zanto.org/">Ayebare Mucunguzi</a>')
             ->and($plugin->author_profile)->toBe('https://profiles.wordpress.org/brooksx/')
-            ->and($plugin->contributors)->toBe([
-                'brooksx' => [
-                    'profile' => 'https://profiles.wordpress.org/brooksx/',
-                    'avatar' => 'https://secure.gravatar.com/avatar/4fa021b564189f92bf90322a1215401d?s=96&d=monsterid&r=g',
-                    'display_name' => 'Ayebare Mucunguzi Brooks',
-                ],
+            ->and($plugin->contributors->toArray()[0])->toMatchArray([
+                'user_nicename' => 'brooksx',
+                'profile' => 'https://profiles.wordpress.org/brooksx/',
+                'avatar' => 'https://secure.gravatar.com/avatar/4fa021b564189f92bf90322a1215401d?s=96&d=monsterid&r=g',
+                'display_name' => 'Ayebare Mucunguzi Brooks',
             ])
             ->and($plugin->requires)->toBe('3.1')
             ->and($plugin->tested)->toBe('4.1.41')
@@ -124,7 +123,10 @@ describe('Sync Plugins', function () {
             ->and($plugin->support_threads_resolved)->toBe(0)
             ->and($plugin->active_installs)->toBe(10)
             ->and($plugin->downloaded)->toBe(2616)
-            ->and($plugin->last_updated)->toBeBetween(new DateTime('2015-01-28 9:41pm GMT'), new DateTime('2015-01-28 10:41pm GMT'))
+            ->and($plugin->last_updated)->toBeBetween(
+                new DateTime('2015-01-28 9:41pm GMT'),
+                new DateTime('2015-01-28 10:41pm GMT'),
+            )
             ->and($plugin->added)->toBeBetween(new DateTime('2015-01-20'), new DateTime('2015-01-21'))
             ->and($plugin->homepage)->toBe('http://example.org/')
             ->and($plugin->sections)->toHaveKeys(['description', 'installation', 'faq', 'changelog', 'reviews'])


### PR DESCRIPTION
# Pull Request

## What changed?

The `contributors` metadata is now used to create Author objects and associate them with their relevant plugin.

Drive by fix: when a new plugin is imported (open or closed), both Plugin and ClosedPlugin entries are now deleted before it's recreated with the proper class

## Why did it change?

Search results for `author` were sub-par before, but should now work as expected

## Did you fix any specific issues?

Closes: #262 
Closes: #285


## CERTIFICATION

By opening this pull request, I do agree to abide by the [Code of Conduct](https://github.com/aspirepress/.github/blob/updating-contributor-policy/CODE_OF_CONDUCT.md) and be bound by the terms of the [Contribution Guidelines](https://github.com/aspirepress/.github/blob/updating-contributor-policy/CONTRIBUTING.md) in effect on the date and time of my contribution as proven by the revision information in GitHub.

