### PR TITLE
Serve downloads directly from S3 and not local filesystem

### DIFF
--- a/app/Services/Downloads/DownloadService.php
+++ b/app/Services/Downloads/DownloadService.php
@@ -4,10 +4,8 @@ namespace App\Services\Downloads;
 
 use App\Contracts\Downloads\Downloader;
 use App\Enums\AssetType;
-use App\Events\AssetCacheHit;
-use App\Events\AssetCacheMissed;
+use App\Jobs\DownloadAssetJob;
 use App\Models\WpOrg\Asset;
-use Illuminate\Support\Facades\Http;
 use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\Storage;
 use Symfony\Component\HttpFoundation\Response;
@@ -17,7 +15,6 @@ class DownloadService implements Downloader
 
     public function download(AssetType $type, string $slug, string $file, ?string $revision = null): Response
     {
-        $public = Storage::disk('public');
         $s3 = Storage::disk('s3');
 
         $context = ['type' => $type->value, 'slug' => $slug, 'file' => $file, 'revision' => $revision];
@@ -39,48 +36,30 @@ class DownloadService implements Downloader
         $path = $asset?->local_path;
         $context['asset'] = $asset;
 
-        if ($asset && !$public->exists($path) && $s3->exists($path)) {
-            Log::debug("Copying $file from s3 to local filesystem", $context);
-            $s3->copy($path, $public->path($path));
-            // fall through to next case now that the file is on local
-        }
-
-        if ($asset && $public->exists($path)) {
-            event(new AssetCacheHit($asset));
-            Log::debug("Serving $file from local filesystem", $context);
-            return redirect($public->url($path)); // must be 301 temp redirect, local files are not guaranteed.
+        if ($asset && $s3->exists($path)) {
+            $url = $s3->temporaryUrl($path, now()->addMinutes(60));
+            Log::debug("Serving $file from s3", [...$context, 'temp_url' => $url]);;
+            return redirect($url);
         }
 
         if ($asset) {
-            Log::info("Deleting stale asset for $file (neither local nor s3 paths exist)", $context);
+            Log::info("Deleting stale asset for $file (missing on s3)", $context);
             $asset->delete();
         }
 
         $upstreamUrl = $type->buildUpstreamUrl($slug, $file, $revision);
         $path = $type->buildLocalPath($slug, $file, $revision);
-        $context['path'] = $path;
 
-        Log::debug("Downloading $file from $upstreamUrl", $context);
-
-        event(
-            new AssetCacheMissed(type: $type, slug: $slug, file: $file, upstreamUrl: $upstreamUrl, revision: $revision),
+        dispatch_sync(
+            new DownloadAssetJob(
+                type: $type,
+                slug: $slug,
+                file: $file,
+                upstreamUrl: $upstreamUrl,
+                revision: $revision,
+            ),
         );
 
-        $response = Http::withHeaders(['User-Agent' => 'AspireCloud'])->get($upstreamUrl);
-
-        if (!$response->successful()) {
-            $status = $response->status();
-            $reason = $response->getReasonPhrase();
-            Log::info("Asset download failed: $reason [url: $upstreamUrl]", [...$context, 'response' => $response]);
-            abort($status, $reason);
-        }
-
-        Log::debug("Saving $file downloaded from $upstreamUrl", $context);
-
-        $stream = $response->resource();
-        $public->put($path, $stream);
-        return redirect($public->url($path)); // must be 301 temp redirect, local files are not guaranteed.
-
-        // return new Response($response->body(), $response->status(), $response->headers());
+        return redirect($s3->temporaryUrl($path, now()->addMinutes(60)));
     }
 }

--- a/config/filesystems.php
+++ b/config/filesystems.php
@@ -52,7 +52,7 @@ return [
             'url' => env('AWS_URL'),
             'endpoint' => env('AWS_ENDPOINT'),
             'use_path_style_endpoint' => env('AWS_USE_PATH_STYLE_ENDPOINT', false),
-            'throw' => false,
+            'throw' => true,
         ],
     ],
 


### PR DESCRIPTION
# Pull Request

## What changed?

Simplifies DownloadController significantly by removing the layer of local filesystem cache, and serving redirects to temporary urls (valid for 1h).  Since S3 supports range requests directly, Fastly will have no problem with them.

## Why did it change?

Aside from simplifying things, this removes a local filesystem dependency so we don't need to provision any extra storage for AC in Kubernetes.

## Did you fix any specific issues?

none

## CERTIFICATION

By opening this pull request, I do agree to abide by the [Code of Conduct](https://github.com/aspirepress/.github/blob/updating-contributor-policy/CODE_OF_CONDUCT.md) and be bound by the terms of the [Contribution Guidelines](https://github.com/aspirepress/.github/blob/updating-contributor-policy/CONTRIBUTING.md) in effect on the date and time of my contribution as proven by the revision information in GitHub.

