### PR TITLE
support /plugins/info/1.0/<slug>.json

### DIFF
--- a/app/Http/Controllers/API/WpOrg/Plugins/PluginInformation_1_0_Controller.php
+++ b/app/Http/Controllers/API/WpOrg/Plugins/PluginInformation_1_0_Controller.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace App\Http\Controllers\API\WpOrg\Plugins;
+
+use App\Http\Controllers\Controller;
+use App\Models\WpOrg\ClosedPlugin;
+use App\Services\Plugins\PluginHotTagsService;
+use App\Services\Plugins\PluginInformationService;
+use App\Services\Plugins\QueryPluginsService;
+use App\Values\WpOrg\Plugins\ClosedPluginResponse;
+use App\Values\WpOrg\Plugins\PluginInformationRequest;
+use App\Values\WpOrg\Plugins\PluginResponse;
+use App\Values\WpOrg\Plugins\QueryPluginsRequest;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+
+class PluginInformation_1_0_Controller extends Controller
+{
+    public function __construct(private readonly PluginInformationService $pluginInfo) {}
+
+    public function __invoke(string $slug): JsonResponse
+    {
+        return $this->pluginInformation(new PluginInformationRequest($slug));
+    }
+
+    private function pluginInformation(PluginInformationRequest $req): JsonResponse
+    {
+        $plugin = $this->pluginInfo->findBySlug($req->slug);
+
+        if (!$plugin) {
+            return response()->json(['error' => 'Plugin not found'], 404);
+        }
+
+        if ($plugin instanceof ClosedPlugin) {
+            $resource = ClosedPluginResponse::from($plugin);
+            $status = 404;
+        } else {
+            $resource = PluginResponse::from($plugin);
+            $status = 200;
+        }
+        return response()->json($resource, $status);
+    }
+}

--- a/routes/api.php
+++ b/routes/api.php
@@ -6,6 +6,7 @@ use App\Http\Controllers\API\WpOrg\Core\BrowseHappyController;
 use App\Http\Controllers\API\WpOrg\Core\ImportersController;
 use App\Http\Controllers\API\WpOrg\Core\ServeHappyController;
 use App\Http\Controllers\API\WpOrg\Core\StableCheckController;
+use App\Http\Controllers\API\WpOrg\Plugins\PluginInformation_1_0_Controller;
 use App\Http\Controllers\API\WpOrg\Plugins\PluginInformation_1_2_Controller;
 use App\Http\Controllers\API\WpOrg\Plugins\PluginUpdateCheck_1_1_Controller;
 use App\Http\Controllers\API\WpOrg\SecretKey\SecretKeyController;
@@ -32,6 +33,7 @@ Route::prefix('/')
         $router->match(['get', 'post'], '/core/stable-check/{version}', StableCheckController::class)->where(['version' => '1.0']);
         $router->get('/core/importers/{version}', ImportersController::class)->where(['version' => '1.[01]']);
 
+        $router->get('/plugins/info/1.0/{slug}.json', PluginInformation_1_0_Controller::class);
         $router->get('/plugins/info/1.2', PluginInformation_1_2_Controller::class);
         $router->post('/plugins/update-check/1.1', PluginUpdateCheck_1_1_Controller::class);
 


### PR DESCRIPTION
# Pull Request

## What changed?

Adds an endpoint to support the /plugins/info/1.0/slug.json format.  Only json is supported, not xml or serialized php.  We almost certainly return a superset of the data that 1.0 expects, but it shouldn't break anything.

## Why did it change?

WooCommerce seems to like to use this, since we see tons of queries every day with this pattern, and it's pretty much always woocommerce.

## Did you fix any specific issues?

Closes: #288 

## CERTIFICATION

By opening this pull request, I do agree to abide by the [Code of Conduct](https://github.com/aspirepress/.github/blob/updating-contributor-policy/CODE_OF_CONDUCT.md) and be bound by the terms of the [Contribution Guidelines](https://github.com/aspirepress/.github/blob/updating-contributor-policy/CONTRIBUTING.md) in effect on the date and time of my contribution as proven by the revision information in GitHub.

