### PR TITLE
Fix: add and use JSON::tryToAssoc to catch json decode errors

### DIFF
--- a/app/Utils/JSON.php
+++ b/app/Utils/JSON.php
@@ -29,6 +29,16 @@ class JSON
         return static::decode($json, true, $depth, $flags);
     }
 
+    /** @return array<string, mixed>|null */
+    public static function tryToAssoc(string $json, int $depth = 512, int $flags = self::DEFAULT_JSON_OPTIONS): ?array
+    {
+        try {
+            return static::toAssoc($json, $depth, $flags);
+        } catch (JsonException) {
+            return null;
+        }
+    }
+
     /** @throws JsonException */
     public static function toObject(string $json, int $depth = 512, int $flags = self::DEFAULT_JSON_OPTIONS): stdClass
     {

--- a/app/Values/WpOrg/Plugins/PluginUpdateCheckRequest.php
+++ b/app/Values/WpOrg/Plugins/PluginUpdateCheckRequest.php
@@ -2,6 +2,7 @@
 
 namespace App\Values\WpOrg\Plugins;
 
+use App\Utils\JSON;
 use App\Values\DTO;
 use Bag\Attributes\Transforms;
 use Illuminate\Http\Request;
@@ -34,7 +35,7 @@ readonly class PluginUpdateCheckRequest extends DTO
     #[Transforms(Request::class)]
     public static function fromRequest(Request $request): array
     {
-        $decode = fn($key) => json_decode($request->post($key), true);
+        $decode = fn($key) => JSON::tryToAssoc($request->post($key) ?? '[]') ?? [];
         return [
             'plugins' => $decode('plugins')['plugins'],
             'locale' => $decode('locale'),

--- a/app/Values/WpOrg/Themes/ThemeUpdateCheckRequest.php
+++ b/app/Values/WpOrg/Themes/ThemeUpdateCheckRequest.php
@@ -2,6 +2,7 @@
 
 namespace App\Values\WpOrg\Themes;
 
+use App\Utils\JSON;
 use App\Values\DTO;
 use Bag\Attributes\Transforms;
 use Illuminate\Http\Request;
@@ -35,7 +36,7 @@ readonly class ThemeUpdateCheckRequest extends DTO
     #[Transforms(Request::class)]
     public static function fromRequest(Request $request): array
     {
-        $decode = fn($key) => json_decode($request->post($key), true);
+        $decode = fn($key) => JSON::tryToAssoc($request->post($key) ?? '[]') ?? [];
         $themes = $decode('themes');
         return [
             'active' => $themes['active'],

--- a/tests/Feature/API/WpOrg/PluginUpdateCheck_1_1_ControllerTest.php
+++ b/tests/Feature/API/WpOrg/PluginUpdateCheck_1_1_ControllerTest.php
@@ -73,6 +73,60 @@ it('returns plugin updates from minimal input', function () {
         ]);
 });
 
+it('uses defaults for malformed requests', function () {
+    Plugin::factory(['slug' => 'frobnicator', 'version' => '1.2.3'])->create();
+    Plugin::factory(['slug' => 'transmogrifier', 'version' => '0.5'])->create();
+
+    $this
+        ->withHeader('Accept', 'application/json')
+        ->post('/plugins/update-check/1.1', [
+            'plugins' => json_encode([
+                'plugins' => [
+                    'frobnicator/frobber.php' => ['Version' => '1.0.2'],    // out of date
+                    'transmogrifier.php' => ['Version' => '0.5'],   // up to date
+                ],
+            ]),
+            'translations' => '', // becomes null!
+            'locale' => 'not_json',
+        ])
+        ->assertStatus(200)
+        ->assertJson([
+            'plugins' => [
+                'frobnicator/frobber.php' => [
+                    'plugin' => 'frobnicator/frobber.php',
+                    'slug' => 'frobnicator',
+                    'new_version' => '1.2.3',
+                ],
+            ],
+        ])
+        ->assertJsonMissingPath('plugins.transmogrifier')
+        ->assertJsonMissingPath('plugins.no_update')
+        ->assertExactJsonStructure([
+            'plugins' => [
+                '*' => [
+                    'banners' => ['high', 'low'],
+                    'banners_rtl',
+                    'compatibility' => [
+                        'php' => ['minimum', 'recommended'],
+                        'wordpress' => ['maximum', 'minimum', 'tested'],
+                    ],
+                    'icons' => ['1x', '2x'],
+                    'id',
+                    'new_version',
+                    'package',
+                    'plugin',
+                    'requires',
+                    'requires_php',
+                    'requires_plugins',
+                    'slug',
+                    'tested',
+                    'url',
+                ],
+            ],
+            'translations',
+        ]);
+});
+
 it('includes no_update when all=true', function () {
     Plugin::factory(['slug' => 'frobnicator', 'version' => '1.2.3'])->create();
     Plugin::factory(['slug' => 'transmogrifier', 'version' => '0.5'])->create();


### PR DESCRIPTION
# Pull Request

## What changed?

Added more robust decoding method for plugin/theme update requests that contain invalid JSON.  

## Why did it change?

Requests where translations were either not provided or an empty string (rather than an empty array) were failing.

## Did you fix any specific issues?

none

## CERTIFICATION

By opening this pull request, I do agree to abide by the [Code of Conduct](https://github.com/aspirepress/.github/blob/updating-contributor-policy/CODE_OF_CONDUCT.md) and be bound by the terms of the [Contribution Guidelines](https://github.com/aspirepress/.github/blob/updating-contributor-policy/CONTRIBUTING.md) in effect on the date and time of my contribution as proven by the revision information in GitHub.

