### PR TITLE
add some generic composer scripts to wrap pint and phpstan

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -50,6 +50,13 @@
         }
     },
     "scripts": {
+        "check": [
+            "@format:check",
+            "@lint"
+        ],
+        "format": "@pint",
+        "format:check": "@pint --test",
+        "lint": "@phpstan",
         "phpstan": "phpstan --memory-limit=2G --verbose",
         "pint": "pint",
         "post-autoload-dump": [


### PR DESCRIPTION
# Pull Request

## What changed?

Adds some generic aliases to composer.json for formatting and static analysis so they're independent of the tools.   

## Why did it change?

Makes it easier to remember which command to tell people to use (these are the commands I use in my $work projects).   

Eventually I'll drop the Makefile, but I haven't completely replaced it with meta/bin scripts, so it's sticking around for the moment.

## Did you fix any specific issues?

none

## CERTIFICATION

By opening this pull request, I do agree to abide by the [Code of Conduct](https://github.com/aspirepress/.github/blob/updating-contributor-policy/CODE_OF_CONDUCT.md) and be bound by the terms of the [Contribution Guidelines](https://github.com/aspirepress/.github/blob/updating-contributor-policy/CONTRIBUTING.md) in effect on the date and time of my contribution as proven by the revision information in GitHub.

