### PR TITLE
fix: Missing content in the `sections` FAIR metadata

### DIFF
--- a/app/Console/Commands/PackageFairImportCommand.php
+++ b/app/Console/Commands/PackageFairImportCommand.php
@@ -2,16 +2,16 @@
 
 namespace App\Console\Commands;
 
+use App\Models\Package;
+use App\Utils\File;
+use App\Values\Packages\FairMetadata;
+use App\Values\Packages\PackageData;
 use Closure;
 use Exception;
-use App\Utils\File;
-use App\Models\Package;
-use Illuminate\Support\Str;
 use Illuminate\Console\Command;
 use Illuminate\Pipeline\Pipeline;
 use Illuminate\Support\Facades\DB;
-use App\Values\Packages\PackageData;
-use App\Values\Packages\FairMetadata;
+use Illuminate\Support\Str;
 
 use function Safe\ini_set;
 use function Safe\json_decode;
@@ -51,8 +51,8 @@ class PackageFairImportCommand extends Command
             } catch (Exception $e) {
                 $this->errors++;
                 $this->error("Line $this->currentLine: {$e->getMessage()}");
-                echo "Partial line: " . Str::substr($line, 0, 100) . "\n";
-                $this->option('stop-on-first-error') and $this->fail("Errors encountered -- aborting.");
+                echo 'Partial line: ' . Str::substr($line, 0, 100) . "\n";
+                $this->option('stop-on-first-error') and $this->fail('Errors encountered -- aborting.');
             }
         }
 

--- a/app/Console/Commands/PackageGenerateFairMetadataCommand.php
+++ b/app/Console/Commands/PackageGenerateFairMetadataCommand.php
@@ -2,10 +2,10 @@
 
 namespace App\Console\Commands;
 
-use Exception;
 use App\Models\Package;
-use Illuminate\Console\Command;
 use App\Values\Packages\FairMetadata;
+use Exception;
+use Illuminate\Console\Command;
 
 use function Safe\json_encode;
 
@@ -40,7 +40,6 @@ class PackageGenerateFairMetadataCommand extends Command
             // For demonstration, we will just output it
             $this->info('Generated FAIR metadata:');
             $this->line(json_encode($fairData, JSON_PRETTY_PRINT));
-
         } catch (Exception $e) {
             $this->error("Error generating FAIR metadata: {$e->getMessage()}");
         }

--- a/app/Console/Commands/PackagePluginsImportCommand.php
+++ b/app/Console/Commands/PackagePluginsImportCommand.php
@@ -2,13 +2,13 @@
 
 namespace App\Console\Commands;
 
-use Exception;
-use App\Models\Package;
 use App\Enums\PackageType;
+use App\Models\Package;
 use App\Models\WpOrg\Plugin;
+use App\Values\Packages\PackageData;
+use Exception;
 use Illuminate\Console\Command;
 use Illuminate\Support\Facades\DB;
-use App\Values\Packages\PackageData;
 
 use function Safe\ini_set;
 
@@ -30,34 +30,36 @@ class PackagePluginsImportCommand extends Command
     {
         ini_set('memory_limit', '-1');
 
-        Plugin::query()->lazy($this->chunkSize)->each(function ($plugin) {
-            $this->currentItem++;
-            $this->info("#$this->currentItem: $plugin->slug");
-            try {
-                DB::beginTransaction();
-                // Plugins don't have a DID, so we use the slug to find existing packages.
-                // @todo - review this logic.
-                $package = Package::query()
-                    ->where([
-                        ['slug', '=', $plugin->slug],
-                        ['type', '=', PackageType::PLUGIN->value],
-                    ])
-                    ->first();
-                if ($package && $this->option('new-only')) {
-                    return;
-                }
-                $package?->delete();
+        Plugin::query()
+            ->lazy($this->chunkSize)
+            ->each(function ($plugin) {
+                $this->currentItem++;
+                $this->info("#$this->currentItem: $plugin->slug");
+                try {
+                    DB::beginTransaction();
+                    // Plugins don't have a DID, so we use the slug to find existing packages.
+                    // @todo - review this logic.
+                    $package = Package::query()
+                        ->where([
+                            ['slug', '=', $plugin->slug],
+                            ['type', '=', PackageType::PLUGIN->value],
+                        ])
+                        ->first();
+                    if ($package && $this->option('new-only')) {
+                        return;
+                    }
+                    $package?->delete();
 
-                Package::fromPackageData(PackageData::from($plugin));
-                $this->loaded++;
-                DB::commit();
-            } catch (Exception $e) {
-                DB::rollBack();
-                $this->errors++;
-                $this->error("Item $this->currentItem: {$e->getMessage()}");
-                $this->option('stop-on-first-error') and $this->fail("Errors encountered -- aborting.");
-            }
-        });
+                    Package::fromPackageData(PackageData::from($plugin));
+                    $this->loaded++;
+                    DB::commit();
+                } catch (Exception $e) {
+                    DB::rollBack();
+                    $this->errors++;
+                    $this->error("Item $this->currentItem: {$e->getMessage()}");
+                    $this->option('stop-on-first-error') and $this->fail('Errors encountered -- aborting.');
+                }
+            });
 
         if ($this->errors > 0) {
             $this->fail("Imported $this->loaded items; $this->errors errors");

--- a/app/Console/Commands/PackageRepoIndexCommand.php
+++ b/app/Console/Commands/PackageRepoIndexCommand.php
@@ -2,14 +2,14 @@
 
 namespace App\Console\Commands;
 
+use App\Values\Packages\FairMetadata;
+use App\Values\Packages\PackageData;
 use Closure;
 use Exception;
 use Illuminate\Console\Command;
-use Illuminate\Support\Facades\Http;
 use Illuminate\Pipeline\Pipeline;
 use Illuminate\Support\Facades\DB;
-use App\Values\Packages\PackageData;
-use App\Values\Packages\FairMetadata;
+use Illuminate\Support\Facades\Http;
 
 use function Safe\ini_set;
 
@@ -31,7 +31,7 @@ class PackageRepoIndexCommand extends Command
 
         $repos = config('fair.repos', []);
         if (empty($repos)) {
-            $this->fail("No FAIR repositories configured. Update the FAIR_REPOS environment variable.");
+            $this->fail('No FAIR repositories configured. Update the FAIR_REPOS environment variable.');
         }
 
         $stages = [
@@ -45,20 +45,22 @@ class PackageRepoIndexCommand extends Command
                 $packages = $this->getRepoPackages($repo);
                 foreach ($packages as $did) {
                     try {
-                        DB::transaction(fn() => $pipeline
-                            ->send($did)
-                            ->through($stages)
-                            ->thenReturn());
+                        DB::transaction(
+                            fn() => $pipeline
+                                ->send($did)
+                                ->through($stages)
+                                ->thenReturn(),
+                        );
                     } catch (Exception $e) {
                         $this->errors++;
                         $this->error("Package $did: {$e->getMessage()}");
-                        $this->option('stop-on-first-error') and $this->fail("Errors encountered -- aborting.");
+                        $this->option('stop-on-first-error') and $this->fail('Errors encountered -- aborting.');
                     }
                 }
             } catch (Exception $e) {
                 $this->errors++;
                 $this->error("Repo $this->currentRepo: {$e->getMessage()}");
-                $this->option('stop-on-first-error') and $this->fail("Errors encountered -- aborting.");
+                $this->option('stop-on-first-error') and $this->fail('Errors encountered -- aborting.');
             }
         }
 
@@ -78,7 +80,7 @@ class PackageRepoIndexCommand extends Command
             'repoUrl' => rtrim($repoUrl, '/'),
             'path' => trim(config('fair.paths.packages', '/wp-json/minifair/v1/packages'), '/'),
         ])->withHeaders(['Accept' => 'application/json'])
-            ->get('{+repoUrl}/{+path}');
+        ->get('{+repoUrl}/{+path}');
 
         if ($response->failed()) {
             throw new Exception("Failed to fetch $repoUrl");
@@ -100,7 +102,7 @@ class PackageRepoIndexCommand extends Command
             'path' => trim(config('fair.paths.packages', '/wp-json/minifair/v1/packages'), '/'),
             'did' => $did,
         ])->withHeaders(['Accept' => 'application/json'])
-            ->get('{+repoUrl}/{+path}/{+did}');
+        ->get('{+repoUrl}/{+path}/{+did}');
 
         if ($response->failed()) {
             throw new Exception("Failed to fetch package metadata from $this->currentRepo");

--- a/app/Http/Controllers/API/FAIR/Packages/PackageInformationController.php
+++ b/app/Http/Controllers/API/FAIR/Packages/PackageInformationController.php
@@ -3,9 +3,9 @@
 namespace App\Http\Controllers\API\FAIR\Packages;
 
 use App\Http\Controllers\Controller;
-use App\Values\Packages\PackageInformationRequest;
 use App\Services\Packages\PackageInformationService;
 use App\Values\Packages\FairMetadata;
+use App\Values\Packages\PackageInformationRequest;
 
 class PackageInformationController extends Controller
 {

--- a/app/Models/Package.php
+++ b/app/Models/Package.php
@@ -12,8 +12,8 @@ use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Database\Eloquent\Relations\HasOne;
 use Illuminate\Support\Arr;
-use Illuminate\Support\Str;
 use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Str;
 
 /**
  * @property-read string                                                        $id
@@ -53,16 +53,16 @@ class Package extends BaseModel
     protected function casts(): array
     {
         return [
-            'id'           => 'string',
-            'did'          => 'string',
-            'slug'         => 'string',
-            'name'         => 'string',
-            'description'  => 'string',
-            'type'         => 'string',
-            'origin'       => 'string',
-            'license'      => 'string',
+            'id' => 'string',
+            'did' => 'string',
+            'slug' => 'string',
+            'name' => 'string',
+            'description' => 'string',
+            'type' => 'string',
+            'origin' => 'string',
+            'license' => 'string',
             'raw_metadata' => 'array',
-            'created_at'   => 'immutable_datetime',
+            'created_at' => 'immutable_datetime',
         ];
     }
 
@@ -131,7 +131,6 @@ class Package extends BaseModel
                         'download_url' => $artifacts['url'] ?? null,
                         'signature' => $artifacts['signature'] ?? null,
                         'checksum' => $artifacts['checksum'] ?? null,
-
                         'requires' => $release['requires'] ?? null,
                         'suggests' => $release['suggests'] ?? null,
                         'provides' => $release['provides'] ?? null,
@@ -146,9 +145,13 @@ class Package extends BaseModel
             $metas = $package->metas['metadata'] ?? [];
 
             $metas['security'] = $packageData->security;
-            $package->metas()->create(
-                ['metadata' => $metas],
-            );
+            $metas['sections'] = $packageData->sections ?? [];
+
+            $package
+                ->metas()
+                ->create(
+                    ['metadata' => $metas],
+                );
 
             return $package;
         });

--- a/app/Models/PackageRelease.php
+++ b/app/Models/PackageRelease.php
@@ -3,7 +3,9 @@
 namespace App\Models;
 
 use Carbon\CarbonImmutable;
+use Database\Factories\PackageReleaseFactory;
 use Illuminate\Database\Eloquent\Concerns\HasUuids;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 
 /**
@@ -24,6 +26,9 @@ class PackageRelease extends BaseModel
 {
     use HasUuids;
 
+    /** @use HasFactory<PackageReleaseFactory> */
+    use HasFactory;
+
     public const UPDATED_AT = null;
 
     protected $table = 'package_releases';
@@ -31,19 +36,17 @@ class PackageRelease extends BaseModel
     protected function casts(): array
     {
         return [
-            'id'           => 'string',
-            'package_id'   => 'string',
-            'version'      => 'string',
+            'id' => 'string',
+            'package_id' => 'string',
+            'version' => 'string',
             'download_url' => 'string',
-            'signature'    => 'string',
-            'checksum'     => 'string',
-
-            'requires'     => 'array',
-            'suggests'     => 'array',
-            'provides'     => 'array',
-            'artifacts'    => 'array',
-
-            'created_at'   => 'immutable_datetime',
+            'signature' => 'string',
+            'checksum' => 'string',
+            'requires' => 'array',
+            'suggests' => 'array',
+            'provides' => 'array',
+            'artifacts' => 'array',
+            'created_at' => 'immutable_datetime',
         ];
     }
 

--- a/app/Models/PackageTag.php
+++ b/app/Models/PackageTag.php
@@ -3,8 +3,10 @@
 namespace App\Models;
 
 use Carbon\CarbonImmutable;
-use Illuminate\Database\Eloquent\Model;
+use Database\Factories\PackageTagFactory;
 use Illuminate\Database\Eloquent\Concerns\HasUuids;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 
 /**
@@ -18,6 +20,9 @@ class PackageTag extends Model
 {
     use HasUuids;
 
+    /** @use HasFactory<PackageTagFactory> */
+    use HasFactory;
+
     public const UPDATED_AT = null;
 
     protected $table = 'package_tags';
@@ -30,9 +35,9 @@ class PackageTag extends Model
     protected function casts(): array
     {
         return [
-            'id'         => 'string',
-            'name'       => 'string',
-            'slug'       => 'string',
+            'id' => 'string',
+            'name' => 'string',
+            'slug' => 'string',
             'created_at' => 'immutable_datetime',
         ];
     }

--- a/app/Values/Packages/FairMetadata.php
+++ b/app/Values/Packages/FairMetadata.php
@@ -202,18 +202,22 @@ readonly class FairMetadata extends DTO
      */
     private static function securityRules(): array
     {
+        // [chuck 2025-09-19] largely disabled for now: some packages make this blank, which aborts the whole import.
         return [
-            'security' => ['required', 'array', 'min:1'],
-            'security.*' => [
-                'required',
-                'array',
-                function (string $attribute, mixed $value, \Closure $fail) {
-                    if (empty($value['url']) && empty($value['email'])) {
-                        $fail("Each security contact must have at least one of 'url' or 'email'.");
-                    }
-                },
-            ],
+            'security' => ['required', 'array'],
         ];
+        // return [
+        //     'security' => ['required', 'array', 'min:1'],
+        //     'security.*' => [
+        //         'required',
+        //         'array',
+        //         function (string $attribute, mixed $value, \Closure $fail) {
+        //             if (empty($value['url']) && empty($value['email'])) {
+        //                 $fail("Each security contact must have at least one of 'url' or 'email'.");
+        //             }
+        //         },
+        //     ],
+        // ];
     }
 
     /**

--- a/app/Values/Packages/FairMetadata.php
+++ b/app/Values/Packages/FairMetadata.php
@@ -7,7 +7,9 @@ use App\Models\Package;
 use App\Utils\Patterns;
 use App\Values\DTO;
 use Bag\Attributes\Hidden;
+use Bag\Attributes\MapOutputName;
 use Bag\Attributes\Transforms;
+use Bag\Mappers\Alias;
 use Bag\Validation\Rules\OptionalOr;
 use Bag\Values\Optional;
 
@@ -32,7 +34,10 @@ readonly class FairMetadata extends DTO
      * @param array<string, mixed> $raw_metadata
      */
     public function __construct(
+        // #[MapInputName(Alias::class, '@context')] // currently mapped by hand in fromMetadata()
+        #[MapOutputName(Alias::class, '@context')]
         public string|array $context, // can be a string or an array of contexts
+
         public string $id,
         public string $type,
         public string $license,

--- a/app/Values/Packages/FairMetadata.php
+++ b/app/Values/Packages/FairMetadata.php
@@ -223,7 +223,8 @@ readonly class FairMetadata extends DTO
             'releases.*.version' => [
                 'required',
                 'string',
-                'regex:' . Patterns::SEMANTIC_VERSION,
+                // [chuck 2025-09-19] disabled for now, some packages have good versions that don't match this.
+                // 'regex:' . Patterns::SEMANTIC_VERSION,
             ],
             'releases.*.artifacts' => ['required', 'array', 'min:1'],
             'releases.*.artifacts.*' => ['required', 'array'],

--- a/app/Values/Packages/PackageData.php
+++ b/app/Values/Packages/PackageData.php
@@ -2,8 +2,8 @@
 
 namespace App\Values\Packages;
 
-use App\Enums\PackageType;
 use App\Enums\Origin;
+use App\Enums\PackageType;
 use App\Models\WpOrg\Plugin;
 use App\Models\WpOrg\Theme;
 use App\Values\DTO;
@@ -17,6 +17,7 @@ readonly class PackageData extends DTO
      * @param array<array<string, string>> $security
      * @param array<array<string, mixed>> $releases
      * @param array<string> $tags
+     * @param array<string, mixed> $sections
      */
     public function __construct(
         public string $did,
@@ -33,6 +34,7 @@ readonly class PackageData extends DTO
         public array $security = [],
         public array $releases = [],
         public array $tags = [],
+        public array $sections = [],
     ) {}
 
     /**
@@ -61,7 +63,7 @@ readonly class PackageData extends DTO
 
         $tags = $fairMetadata->raw_metadata['keywords'] ?? [];
 
-        return [
+        $ret = [
             'did' => $fairMetadata->id,
             'type' => $fairMetadata->type,
             'origin' => Origin::FAIR->value,
@@ -77,6 +79,12 @@ readonly class PackageData extends DTO
             'releases' => $releases,
             'tags' => $tags,
         ];
+
+        if ($fairMetadata->sections) {
+            $ret['sections'] = $fairMetadata->sections;
+        }
+
+        return $ret;
     }
 
     /**
@@ -96,9 +104,11 @@ readonly class PackageData extends DTO
 
         $security = [
             [
-                'url' => ($authorUrl ?? $plugin->author_profile) ?? $plugin->support_url,
+                'url' => $authorUrl ?? $plugin->author_profile ?? $plugin->support_url,
             ],
         ];
+
+        $sections = $plugin->ac_raw_metadata['sections'] ?? null;
 
         $releases = [
             [
@@ -115,7 +125,7 @@ readonly class PackageData extends DTO
 
         $tags = $plugin->tags()->pluck('name')->toArray();
 
-        return [
+        $ret = [
             'did' => 'fake:' . $plugin->slug, // @todo - generate a real DID
             'type' => PackageType::PLUGIN->value,
             'origin' => Origin::WP->value,
@@ -136,6 +146,12 @@ readonly class PackageData extends DTO
             'releases' => $releases,
             'tags' => $tags,
         ];
+
+        if ($sections) {
+            $ret['sections'] = $sections;
+        }
+
+        return $ret;
     }
 
     /**
@@ -164,9 +180,11 @@ readonly class PackageData extends DTO
             ],
         ];
 
+        $sections = $theme->ac_raw_metadata['sections'] ?? null;
+
         $tags = $theme->tags()->pluck('name')->toArray();
 
-        return [
+        $ret = [
             'did' => 'fake:' . $theme->slug, // @todo - generate a real DID
             'type' => PackageType::THEME->value,
             'origin' => Origin::WP->value,
@@ -187,6 +205,12 @@ readonly class PackageData extends DTO
             'releases' => $releases,
             'tags' => $tags,
         ];
+
+        if ($sections) {
+            $ret['sections'] = $sections;
+        }
+
+        return $ret;
     }
 
     /** @return array<string, mixed> */
@@ -205,6 +229,7 @@ readonly class PackageData extends DTO
             'security' => ['required', 'array'],
             'releases' => ['required', 'array'],
             'tags' => ['sometimes', 'array'],
+            'sections' => ['sometimes', 'array'],
         ];
     }
 }

--- a/app/Values/Packages/PackageData.php
+++ b/app/Values/Packages/PackageData.php
@@ -104,7 +104,7 @@ readonly class PackageData extends DTO
 
         $security = [
             [
-                'url' => $authorUrl ?? $plugin->author_profile ?? $plugin->support_url,
+                'url' => 'https://wordpress.org/about/security/',
             ],
         ];
 
@@ -163,7 +163,7 @@ readonly class PackageData extends DTO
     {
         $security = [
             [
-                'url' => $theme->author['author_url'],
+                'url' => 'https://wordpress.org/about/security/',
             ],
         ];
 

--- a/app/Values/Packages/PackageInformationRequest.php
+++ b/app/Values/Packages/PackageInformationRequest.php
@@ -12,7 +12,9 @@ readonly class PackageInformationRequest extends DTO
 {
     public const ACTION = 'package_information';
 
-    public function __construct(public string $did) {}
+    public function __construct(
+        public string $did,
+    ) {}
 
     /** @return array<string, mixed> */
     #[Transforms(Request::class)]

--- a/database/factories/PackageFactory.php
+++ b/database/factories/PackageFactory.php
@@ -4,9 +4,10 @@ namespace Database\Factories;
 
 use App\Models\Package;
 use App\Models\PackageTag;
-use Illuminate\Support\Str;
 use App\Models\WpOrg\Author;
+use Database\Factories\PackageReleaseFactory;
 use Illuminate\Database\Eloquent\Factories\Factory;
+use Illuminate\Support\Str;
 
 /** @extends Factory<Package> */
 class PackageFactory extends Factory
@@ -81,18 +82,23 @@ class PackageFactory extends Factory
     public function withReleases(int $count = 1): static
     {
         return $this->afterCreating(function (Package $package) use ($count) {
-            $package->releases()->createMany(
-                PackageReleaseFactory::new()->count($count)->make([
-                    'package_id' => $package->id,
-                ])->toArray(),
-            );
+            $package
+                ->releases()
+                ->createMany(
+                    PackageReleaseFactory::new()
+                        ->count($count)
+                        ->make([
+                            'package_id' => $package->id,
+                        ])
+                        ->toArray(),
+                );
         });
     }
 
     public function withMetas(array $metas = []): static
     {
         return $this->afterCreating(function (Package $package) use ($metas) {
-            $package->metas()->create(array_merge([
+            $data = [
                 'metadata' => [
                     'security' => [
                         [
@@ -100,7 +106,11 @@ class PackageFactory extends Factory
                         ],
                     ],
                 ],
-            ], $metas));
+            ];
+
+            $data['metadata'] = array_merge($data['metadata'], $metas);
+
+            $package->metas()->create($data);
         });
     }
 }

--- a/database/factories/PackageReleaseFactory.php
+++ b/database/factories/PackageReleaseFactory.php
@@ -6,7 +6,7 @@ use App\Models\Package;
 use App\Models\PackageRelease;
 use Illuminate\Database\Eloquent\Factories\Factory;
 
-/** @extends Factory<Package> */
+/** @extends Factory<PackageRelease> */
 class PackageReleaseFactory extends Factory
 {
     protected $model = PackageRelease::class;

--- a/database/factories/PackageTagFactory.php
+++ b/database/factories/PackageTagFactory.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\Package;
+use App\Models\PackageTag;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/** @extends Factory<PackageTag> */
+class PackageTagFactory extends Factory
+{
+    protected $model = PackageTag::class;
+
+    public function definition(): array
+    {
+        return [
+            'id' => $this->faker->uuid(),
+            'name' => $this->faker->word(),
+            'slug' => $this->faker->unique()->slug(),
+        ];
+    }
+}

--- a/tests/Feature/API/FAIR/PackageInformationControllerTest.php
+++ b/tests/Feature/API/FAIR/PackageInformationControllerTest.php
@@ -9,7 +9,7 @@ beforeEach(function () {
 
 function package_information_uri(string $did): string
 {
-    return "/packages/" . $did;
+    return '/packages/' . $did;
 }
 
 it('returns 404 when did is missing', function () {
@@ -44,8 +44,46 @@ it('returns package information in FAIR format', function () {
             'raw_metadata' => [],
         ]);
 
-    $this
-        ->getJson(package_information_uri('fake:test-package'))
+    $this->getJson(package_information_uri('fake:test-package'))
+        ->assertStatus(200)
+        ->assertJsonStructure(
+            [
+                'context',
+                'id',
+                'type',
+                'license',
+                'authors',
+                'security',
+                'releases',
+                'slug',
+                'name',
+                'description',
+            ],
+        );
+});
+
+it('returns package information in FAIR format with optional fields', function () {
+    Package::factory()
+        ->withAuthors()
+        ->withReleases(3)
+        ->withTags()
+        ->withMetas([
+            'sections' => [
+                'installation' => 'Installation instructions here.',
+                'changelog' => 'Changelog details here.',
+            ],
+        ])
+        ->create([
+            'did' => 'fake:test-package2',
+            'name' => 'Test Package2',
+            'slug' => 'test-package2',
+            'origin' => 'wp',
+            'type' => 'wp-theme',
+            'license' => 'MIT',
+            'raw_metadata' => [],
+        ]);
+
+    $this->getJson(package_information_uri('fake:test-package2'))
         ->assertStatus(200)
         ->assertJsonStructure(
             [
@@ -58,7 +96,6 @@ it('returns package information in FAIR format', function () {
                 'releases',
                 'keywords',
                 'sections',
-                '_links',
                 'slug',
                 'name',
                 'description',

--- a/tests/Feature/API/FAIR/PackageInformationControllerTest.php
+++ b/tests/Feature/API/FAIR/PackageInformationControllerTest.php
@@ -48,7 +48,7 @@ it('returns package information in FAIR format', function () {
         ->assertStatus(200)
         ->assertJsonStructure(
             [
-                'context',
+                '@context',
                 'id',
                 'type',
                 'license',

--- a/tests/Feature/Services/Packages/PackageInformationServiceTest.php
+++ b/tests/Feature/Services/Packages/PackageInformationServiceTest.php
@@ -12,7 +12,11 @@ beforeEach(function () {
 test('packageInformation with DID returns matching package', function () {
     // Create packages with specific names
     Package::factory()->create(['did' => 'fake:test-package', 'name' => 'Test Package', 'slug' => 'test-package']);
-    Package::factory()->create(['did' => 'fake:another-package', 'name' => 'Another Package', 'slug' => 'another-package']);
+    Package::factory()->create([
+        'did' => 'fake:another-package',
+        'name' => 'Another Package',
+        'slug' => 'another-package',
+    ]);
 
     // Create the service
     $service = new PackageInformationService();
@@ -22,5 +26,6 @@ test('packageInformation with DID returns matching package', function () {
     // Assert the response contains the matching plugin
     expect($package)
         ->toBeInstanceOf(Package::class)
-        ->and($package->name)->toBe('Test Package');
+        ->and($package->name)
+        ->toBe('Test Package');
 });


### PR DESCRIPTION
# Pull Request

## What changed?

- Populate the `sections` property of the FAIR metadata, if it exists in the original package/plugin/theme.
- Do not generate empty arrays for the missing optional properties (`sections`, `keywords`, `_links`).
- Add missing factory class
- Code formatting


## Why did it change?

Incorrect/incomplete FAIR metadata generation.

## Did you fix any specific issues?

#347 

## CERTIFICATION

By opening this pull request, I do agree to abide by the [Code of Conduct](https://github.com/aspirepress/.github/blob/updating-contributor-policy/CODE_OF_CONDUCT.md) and be bound by the terms of the [Contribution Guidelines](https://github.com/aspirepress/.github/blob/updating-contributor-policy/CONTRIBUTING.md) in effect on the date and time of my contribution as proven by the revision information in GitHub.

