### PR TITLE
web did endpoint and controller

### DIFF
--- a/app/Http/Controllers/API/WpOrg/WebController.php
+++ b/app/Http/Controllers/API/WpOrg/WebController.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace App\Http\Controllers\API\WpOrg;
+
+use App\Http\Controllers\Controller;
+use App\Models\Package;
+use Illuminate\Http\JsonResponse;
+
+class WebController extends Controller
+{
+    /**
+     * Display the specified resource.
+     *
+     * @param  string  $slug
+     * @return JsonResponse
+     */
+    public function showWebDid(string $slug): JsonResponse
+    {
+        // Validate the slug
+        $packageBuilder = $this->validateSlug($slug);
+
+        if (! $packageBuilder->exists()) {
+            return response()->json(['message' => 'Not Found'], 404);
+        }
+
+        $package = $packageBuilder->first();
+
+        $host = request()->getHost();
+
+        $didPath = str_replace('/', ':', $slug);
+        $did = 'did:web:' . $host . ':' . $didPath;
+
+        $didDocument = [
+            '@context' => [
+                'https://www.w3.org/ns/did/v1',
+                'https://w3id.org/security/multikey/v1',
+                'https://w3id.org/security/suites/secp256k1-2019/v1',
+            ],
+            'alsoKnownAs' => [
+                "https://wordpress.org/plugins/{$slug}",
+                $package->origin ?? '',
+            ],
+            'id' => $did,
+            'service' => [
+                [
+                    'id' => '#fairpm_repo',
+                    'serviceEndpoint' => route('packages.show', $package->id),
+                    'type' => 'FairPackageManagementRepo',
+                ],
+            ],
+            'verificationMethod' => [
+               //
+            ],
+        ];
+
+        return response()->json($didDocument, 200, [], JSON_UNESCAPED_SLASHES);
+    }
+
+    /**
+     * Validate the slug
+     *
+     * @param  string  $slug
+     * @return bool
+     */
+    private function validateSlug(string $slug): bool
+    {
+         return Package::query()->where('slug', $slug);
+    }
+}

--- a/routes/api.php
+++ b/routes/api.php
@@ -18,6 +18,7 @@ use App\Http\Controllers\API\FAIR\Packages\PackageInformationController;
 use App\Http\Controllers\API\WpOrg\Plugins\PluginInformation_1_0_Controller;
 use App\Http\Controllers\API\WpOrg\Plugins\PluginInformation_1_2_Controller;
 use App\Http\Controllers\API\WpOrg\Plugins\PluginUpdateCheck_1_1_Controller;
+use App\Http\Controllers\API\WpOrg\WebController;
 
 // https://codex.wordpress.org/WordPress.org_API
 
@@ -75,6 +76,7 @@ Route::prefix('/')
         $router->any('/translations/themes/{version}', PassThroughController::class)->where(['version' => '1.0']);
 
         $router->get('/packages/{did}', PackageInformationController::class);
+        $router->get('/packages/{slug}/did.json', [WebController::class, 'showWebDid']);
 
         // @formatter:on
     });


### PR DESCRIPTION
# Pull Request

## What changed?

- Addition of a web did endpoint
- A web controller formatting the web did and responding.

## CERTIFICATION

By opening this pull request, I do agree to abide by the [Code of Conduct](https://github.com/aspirepress/.github/blob/updating-contributor-policy/CODE_OF_CONDUCT.md) and be bound by the terms of the [Contribution Guidelines](https://github.com/aspirepress/.github/blob/updating-contributor-policy/CONTRIBUTING.md) in effect on the date and time of my contribution as proven by the revision information in GitHub.

