### PR TITLE
fix: pass through null theme fields in response as-is, do not omit them

### DIFF
--- a/app/Values/WpOrg/Themes/ThemeResponse.php
+++ b/app/Values/WpOrg/Themes/ThemeResponse.php
@@ -27,30 +27,30 @@ readonly class ThemeResponse extends DTO
         public string $name,
         public string $slug,
         public string $version,
-        public string $preview_url,
+        public string|null $preview_url,
         public Optional|Author|string $author,
         public Optional|string $description,
-        public Optional|string $screenshot_url,
+        public Optional|string|null $screenshot_url,
         public Optional|array $ratings, // TODO: ensure this casts to array correctly
         public Optional|int $rating,
         public Optional|int $num_ratings,
-        public Optional|string $reviews_url,
+        public Optional|string|null $reviews_url,
         public Optional|int $downloaded,
         public Optional|int $active_installs,
-        public Optional|string $last_updated,
-        public Optional|string $last_updated_time,
+        public Optional|string|null $last_updated,
+        public Optional|string|null $last_updated_time,
         public Optional|string $creation_time,
-        public Optional|string $homepage,
+        public Optional|string|null $homepage,
         public Optional|array $sections,
         public Optional|string $download_link,
         public Optional|array $tags,
         public Optional|array $versions,
-        public Optional|string $requires,
-        public Optional|string $requires_php,
+        public Optional|string|null $requires,
+        public Optional|string|null $requires_php,
         public Optional|bool $is_commercial,
-        public Optional|string $external_support_url,
+        public Optional|string|null $external_support_url,
         public Optional|bool $is_community,
-        public Optional|string $external_repository_url,
+        public Optional|string|null $external_repository_url,
         #[Hidden]
         public Optional|Author $extended_author,
 
@@ -70,55 +70,50 @@ readonly class ThemeResponse extends DTO
 
     /**
      * @return array<string, mixed>
-     * @noinspection ProperNullCoalescingOperatorUsageInspection (it's fine here)
      */
     #[Transforms(Theme::class)]
     public static function fromTheme(Theme $theme): array
     {
-        // Note we fill in all fields, then strip out any not-requested Optional.  such silliness is compatibility.
-
-        $none = new Optional();
         return [
             'name' => $theme->name,
             'slug' => $theme->slug,
             'version' => $theme->version,
             'preview_url' => $theme->preview_url,
-            'author' => $theme->author ?? $none,
-            // gets converted to $theme->author->user_nicename unless extended_author=true
-            'description' => $theme->description ?? $none,
-            'screenshot_url' => $theme->screenshot_url ?? $none,
-            'ratings' => $theme->ratings ?? $none,
-            'rating' => $theme->rating ?? $none,
-            'num_ratings' => $theme->num_ratings ?? $none,
-            'reviews_url' => $theme->reviews_url ?? $none,
-            'downloaded' => $theme->downloaded ?? $none,
-            'active_installs' => $theme->active_installs ?? $none,
-            'last_updated' => $theme->last_updated?->format('Y-m-d') ?? $none,
-            'last_updated_time' => $theme->last_updated?->format('Y-m-d H:i:s') ?? $none,
-            'creation_time' => $theme->creation_time?->format('Y-m-d H:i:s') ?? $none,
+            'author' => $theme->author, // gets converted to $theme->author->user_nicename unless extended_author=true
+            'description' => $theme->description,
+            'screenshot_url' => $theme->screenshot_url,
+            'ratings' => $theme->ratings,
+            'rating' => $theme->rating,
+            'num_ratings' => $theme->num_ratings,
+            'reviews_url' => $theme->reviews_url,
+            'downloaded' => $theme->downloaded,
+            'active_installs' => $theme->active_installs,
+            'last_updated' => $theme->last_updated?->format('Y-m-d'),
+            'last_updated_time' => $theme->last_updated?->format('Y-m-d H:i:s'),
+            'creation_time' => $theme->creation_time?->format('Y-m-d H:i:s'),
             'homepage' => "https://wordpress.org/themes/{$theme->slug}/",
-            'sections' => $theme->sections ?? $none,
-            'download_link' => $theme->download_link ?? $none,
+            'sections' => $theme->sections,
+            'download_link' => $theme->download_link,
             'tags' => $theme->tagsArray(),
-            'versions' => $theme->versions ?? $none,
-            'requires' => $theme->requires ?? $none,
-            'requires_php' => $theme->requires_php ?? $none,
-            'is_commercial' => $theme->is_commercial ?? $none,
+            'versions' => $theme->versions,
+            'requires' => $theme->requires,
+            'requires_php' => $theme->requires_php,
+            'is_commercial' => $theme->is_commercial,
             'external_support_url' => $theme->external_support_url,
-            'is_community' => $theme->is_community ?? $none,
+            'is_community' => $theme->is_community,
             'external_repository_url' => $theme->external_repository_url,
 
             // hidden
             'extended_author' => $theme->author,
 
             // eventual support
-            'parent' => $none,
-            'screenshot_count' => $none,
-            'screenshots' => $none,
-            'theme_url' => $none,
-            'photon_screenshots' => $none,
-            'trac_tickets' => $none,
-            'upload_date' => $none,
+            // 'parent' => $none,
+            // 'screenshot_count' => $none,
+            // 'screenshots' => $none,
+            // 'theme_url' => $none,
+            // 'photon_screenshots' => $none,
+            // 'trac_tickets' => $none,
+            // 'upload_date' => $none,
 
             // ac meta
             'ac_origin' => $theme->ac_origin,


### PR DESCRIPTION
# Pull Request

## What changed?

When a Theme's field like `requires` is null, pass that null through in responses, rather than stripping it out.

## Why did it change?

The missing `requires` field was causing WP to throw warnings, since it always assumes it's there.  In .org responses, it's actually `false`, but I'm reasonably sure `null` will be treated the same.

## Did you fix any specific issues?

Closes: #368

## CERTIFICATION

By opening this pull request, I do agree to abide by the [Code of Conduct](https://github.com/aspirepress/.github/blob/updating-contributor-policy/CODE_OF_CONDUCT.md) and be bound by the terms of the [Contribution Guidelines](https://github.com/aspirepress/.github/blob/updating-contributor-policy/CONTRIBUTING.md) in effect on the date and time of my contribution as proven by the revision information in GitHub.

