### PR TITLE
 remove N+1 selects from InlineFairMetadata 

### DIFF
--- a/app/Http/Middleware/Hacks/InlineFairMetadata.php
+++ b/app/Http/Middleware/Hacks/InlineFairMetadata.php
@@ -81,6 +81,7 @@ readonly class InlineFairMetadata
         if (!$slug) {
             return $item;
         }
+        assert(is_string($slug));
         $fair = $fair_meta[$slug] ?? null;
         if (!$fair) {
             return $item;


### PR DESCRIPTION
# Pull Request

## What changed?

Switches from N+1 selects to querying for FAIR metadata directly, always using the `packages.raw_metadata` column, which is always populated anyway.

## Why did it change?

Keeps AC from falling over when tag searches are done with the _fair key.

## Did you fix any specific issues?

Closes: #369

## CERTIFICATION

By opening this pull request, I do agree to abide by the [Code of Conduct](https://github.com/aspirepress/.github/blob/updating-contributor-policy/CODE_OF_CONDUCT.md) and be bound by the terms of the [Contribution Guidelines](https://github.com/aspirepress/.github/blob/updating-contributor-policy/CONTRIBUTING.md) in effect on the date and time of my contribution as proven by the revision information in GitHub.

