### PR TITLE
DownloadService redirect to upstream URL if S3 is not configured

### DIFF
--- a/app/Services/Downloads/DownloadService.php
+++ b/app/Services/Downloads/DownloadService.php
@@ -22,15 +22,30 @@ class DownloadService implements Downloader
         ?string $revision = null,
     ): Response
     {
-        $s3 = Storage::disk('s3');
-
-        $context = ['type' => $type->value, 'slug' => $slug, 'file' => $file, 'revision' => $revision];
-        Log::debug("DOWNLOAD", $context);
-
         if ($revision === 'head') {
             // head is there to have something in the url, but it behaves the same as not passing it
             $revision = null;
         }
+
+        try {
+            $s3 = Storage::disk('s3');
+        } catch (\Exception) {
+            // HACK: S3 is not configured, so redirect everything back to .org after all
+            // FIXME: use FILESYSTEM_DISK from config and deal with Laravel's godawful Storage facade
+            $upstream_url = $type->buildUpstreamUrl($slug, $file, $revision);
+            $context = [
+                'type' => $type->value,
+                'slug' => $slug,
+                'file' => $file,
+                'revision' => $revision,
+                'upstream_url' => $upstream_url,
+            ];
+            Log::warning("Could not instantiate S3 storage -- redirecting to original URL", $context);
+            return redirect()->to($upstream_url);
+        }
+
+        $context = ['type' => $type->value, 'slug' => $slug, 'file' => $file, 'revision' => $revision];
+        Log::debug("DOWNLOAD", $context);
 
         $path = $type->buildLocalPath($slug, $file, $revision);
 
@@ -44,7 +59,13 @@ class DownloadService implements Downloader
         $s3 = Storage::disk('s3');
         $path = $type->buildLocalPath($slug, $file, $revision);
         $upstream_url = $type->buildUpstreamUrl($slug, $file, $revision);
-        $context['upstream_url'] = $upstream_url;
+        $context = [
+            'type' => $type->value,
+            'slug' => $slug,
+            'file' => $file,
+            'revision' => $revision,
+            'upstream_url' => $upstream_url,
+        ];
 
         Log::debug("Downloading $file from $upstream_url", $context);
 


### PR DESCRIPTION
# Pull Request

## What changed?

If `Storage::disk('s3')` throws any exceptions in DownloadService, a redirect to the upstream URL is sent back, effectively turning our elaborate rewrite mechanism into a no-op.  Except for breaking trunk downloads (ones without a version) but that's something that can be fixed later.

## Why did it change?

Everything breaks if S3 is not set up, and we don't have a local S3 service running in Docker.  We probably want to do that, but given recent developments, we'll want to find something that isn't Minio...

## Did you fix any specific issues?

none.  h/t to @schlessera for noticing it

## CERTIFICATION

By opening this pull request, I do agree to abide by the [Code of Conduct](https://github.com/aspirepress/.github/blob/updating-contributor-policy/CODE_OF_CONDUCT.md) and be bound by the terms of the [Contribution Guidelines](https://github.com/aspirepress/.github/blob/updating-contributor-policy/CONTRIBUTING.md) in effect on the date and time of my contribution as proven by the revision information in GitHub.

